### PR TITLE
Replaced DOMNodeInserted with MutationObserver

### DIFF
--- a/src/TagzApp.Web/wwwroot/js/site.js
+++ b/src/TagzApp.Web/wwwroot/js/site.js
@@ -3,7 +3,29 @@
 	var connection;
 
 	const taggedContent = document.getElementById("taggedContent");
+	const observer = new MutationObserver(function (mutationsList, observer) {
+		for (const mutation of mutationsList) {
+			if (mutation.type !== 'childList') continue;
+			for (const node of mutation.addedNodes) {
+				const imgCardTop = node.querySelector(".card-img-top");
+				if (imgCardTop !== null) {
+					imgCardTop.addEventListener("load", function (ev) {
+						window.Masonry.resizeGridItem(node);
+					}, false);
+					imgCardTop.addEventListener("error", function (ev) {
+						window.Masonry.resizeGridItem(node);
+					}, false);
+				} else {
+					window.Masonry.resizeGridItem(node);
+				}
+            }
+		}
+	});
+	const observerConfig = {
+		childList: true
+	};
 
+	observer.observe(taggedContent, observerConfig);
 	async function start() {
 		try {
 			await connection.start();
@@ -50,15 +72,6 @@
 			`
 		}
 
-		if (content.previewCard) {
-			newMessage.querySelector(".card-img-top").addEventListener("load", function (ev) {
-				window.Masonry.resizeGridItem(newMessage);
-			}, false);
-		} else {
-			newMessage.addEventListener("DOMNodeInserted", function (ev) {
-				window.Masonry.resizeGridItem(newMessage);
-			}, false);
-		}
 		newMessage.addEventListener("click", function (ev) {
 
 			var el = ev.target.closest('article');


### PR DESCRIPTION
I noticed that there was a warning in the browser console:
```
[Deprecation] Listener added for a synchronous 'DOMNodeInserted' DOM Mutation Event.
This event type is deprecated (https://w3c.github.io/uievents/#legacy-event-types) and work is underway to remove it from this browser.
Usage of this event listener will cause performance issues today, and represents a risk of future incompatibility.
Consider using MutationObserver instead.
```

> Chromium has officially deprecated mutation events, and has a plan to remove support starting with version 127, which goes to stable release on July 30, 2024.

https://developer.chrome.com/blog/mutation-events-deprecation/

> Deprecated: This feature is no longer recommended.

https://developer.mozilla.org/en-US/docs/Web/API/MutationEvent/

As far as I can tell there is no change in behavior on the site with this change.