### PR TITLE
Use compression on sample data for twitter provider.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -411,3 +411,5 @@ FodyWeavers.xsd
 *.db
 *.db-shm
 *.db-wal
+
+/src/TagzApp.Providers.Twitter/Models/SampleTweets.json.gz

--- a/src/TagzApp.Providers.Twitter/TagzApp.Providers.Twitter.csproj
+++ b/src/TagzApp.Providers.Twitter/TagzApp.Providers.Twitter.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
@@ -23,5 +23,64 @@
     <ProjectReference Include="..\TagzApp.Common\TagzApp.Common.csproj" />
     <ProjectReference Include="..\TagzApp.Communication\TagzApp.Communication.csproj" />
 	</ItemGroup>
+
+  <UsingTask TaskName="GZip" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
+    <ParameterGroup>
+      <Files ParameterType="Microsoft.Build.Framework.ITaskItem[]" Required="true" />
+      <Result ParameterType="Microsoft.Build.Framework.ITaskItem[]" Output="true" />
+    </ParameterGroup>
+    <Task>
+      <Using Namespace="System.IO" />
+      <Using Namespace="System.IO.Compression" />
+      <Code Type="Fragment" Language="cs">
+        <![CDATA[
+    if (Files.Length > 0)
+    {
+        Result = new TaskItem[Files.Length];
+        for (int i = 0; i < Files.Length; i++)
+        {
+            ITaskItem item = Files[i];
+            string sourcePath = item.GetMetadata("FullPath");
+            string sourceItemSpec = item.ItemSpec;
+                  
+            string destinationSuffix = ".gz";
+            string destinationPath = sourcePath + destinationSuffix;
+            string destinationItemSpec = sourceItemSpec + destinationSuffix;
+
+            Log.LogMessage(MessageImportance.Normal, 
+                "EmbeddedResource Src : " + sourceItemSpec);
+                  
+            using (var sourceStream = File.OpenRead(sourcePath))
+            using (var destinationStream = File.OpenWrite(destinationPath))
+            using (var destinationGZip = new GZipStream(destinationStream, 
+              CompressionLevel.Optimal))
+            {
+                sourceStream.CopyTo(destinationGZip);
+            }
+                  
+            var destinationItem = new TaskItem(destinationItemSpec);
+            
+            Log.LogMessage(MessageImportance.Normal, 
+                "EmbeddedResource GZip: " + destinationItem.ItemSpec);
+                  
+            Result[i] = destinationItem;
+        }
+    }
+  ]]>
+      </Code>
+    </Task>
+  </UsingTask>
+
+  <Target Name="GZip" BeforeTargets="BeforeBuild">
+    <GZip Files="@(EmbeddedResource)">
+      <Output ItemName="GZipEmbeddedResource" TaskParameter="Result" />
+    </GZip>
+    <Message Text="Source EmbeddedResources: @(EmbeddedResource)" Importance="High" />
+    <Message Text="GZipped EmbeddedResources: @(GZipEmbeddedResource)" Importance="High" />
+    <ItemGroup>
+      <EmbeddedResource Remove="@(EmbeddedResource)" />
+      <EmbeddedResource Include="@(GZipEmbeddedResource)" />
+    </ItemGroup>
+  </Target>
 
 </Project>

--- a/src/TagzApp.Providers.Twitter/TwitterProvider.cs
+++ b/src/TagzApp.Providers.Twitter/TwitterProvider.cs
@@ -1,4 +1,5 @@
-﻿using System.Net.Http.Json;
+﻿using System.IO.Compression;
+using System.Net.Http.Json;
 using System.Reflection;
 using System.Text.Json;
 using System.Web;
@@ -49,16 +50,16 @@ public class TwitterProvider : ISocialMediaProvider
 #else
 
 			var assembly = Assembly.GetExecutingAssembly();
-			var resourceName = "TagzApp.Providers.Twitter.Models.SampleTweets.json";
+			var resourceName = "TagzApp.Providers.Twitter.Models.SampleTweets.json.gz";
 			string sampleJson = string.Empty;
 
-			using (Stream stream = assembly.GetManifestResourceStream(resourceName))
-			using (StreamReader reader = new StreamReader(stream))
+			using var stream = assembly.GetManifestResourceStream(resourceName);
+			if (stream is not null)
 			{
-				sampleJson = reader.ReadToEnd();
+				using var unzip = new GZipStream(stream, CompressionMode.Decompress);
+				var embeddedTweets = JsonSerializer.Deserialize<TwitterData>(unzip);
+				if (embeddedTweets is not null) recentTweets = embeddedTweets;
 			}
-			recentTweets = JsonSerializer.Deserialize<TwitterData>(sampleJson);
-
 #endif
 
 		}


### PR DESCRIPTION
Directly deserialize json from (gzip)stream without creating an intermediate string to reduce memory load. Ignores .gz file created in project by build task which runs on build to replace EmbeddedResources with .gz versions. https://nietras.com/2020/10/04/gzip-embeddedresource/ Reduces dll from ~186Kb to ~66Kb