### PR TITLE
Added new Blazot Social Network provider as an option.

### DIFF
--- a/src/TagzApp.Providers.Blazot/BlazotProvider.cs
+++ b/src/TagzApp.Providers.Blazot/BlazotProvider.cs
@@ -1,0 +1,73 @@
+﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Configuration;
+using TagzApp.Providers.Blazot.Constants;
+using TagzApp.Providers.Blazot.Interfaces;
+using TagzApp.Providers.Blazot.Models;
+using TagzApp.Providers.Blazot.Configuration;
+
+namespace TagzApp.Providers.Blazot;
+
+internal sealed class BlazotProvider : ISocialMediaProvider
+{
+  private readonly int _WindowSeconds;
+  private readonly int _WindowRequests;
+  private readonly ILogger<BlazotProvider> _Logger;
+  private readonly IContentConverter _ContentConverter;
+  private readonly ITransmissionsService _TransmissionsService;
+  private readonly IAuthService _AuthService;
+  public TimeSpan NewContentRetrievalFrequency => TimeSpan.FromSeconds((double)_WindowSeconds / _WindowRequests);
+  public string Id => BlazotConstants.ProviderId;
+  public string DisplayName => BlazotConstants.DisplayName;
+
+  public BlazotProvider(ILogger<BlazotProvider> logger, IConfiguration configuration, 
+    IContentConverter contentConverter, ITransmissionsService transmissionsService, IAuthService authService)
+  {
+    _ContentConverter = contentConverter ?? throw new ArgumentNullException(nameof(contentConverter));
+    _TransmissionsService = transmissionsService ?? throw new ArgumentNullException(nameof(transmissionsService));
+    _AuthService = authService ?? throw new ArgumentNullException(nameof(authService));
+    _Logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+    var settings = configuration.GetSection(BlazotSettings.AppSettingsSection).Get<BlazotSettings>();
+    _WindowSeconds = settings?.WindowSeconds ?? throw new ArgumentNullException(nameof(settings));
+    _WindowRequests = settings.WindowRequests;
+  }
+
+  public async Task<IEnumerable<Content>> GetContentForHashtag(Hashtag tag, DateTimeOffset dateTimeOffset)
+  {
+    var transmissions = new List<Transmission>();
+
+    try
+    {
+      // Throttle requests in case of exceeded rate.
+      // Requesting multiple tags within a loop could make more requests than expected.
+      // Some refactoring could be done to request multiple tags if app is adjusted to send them in a single call.
+      // A Blazot hashtags request can currently accept up to 10 hashtags with "?t=sometag&t=anothertag".
+      if (_TransmissionsService.HasMadeTooManyRequests)
+      {
+        _Logger.LogInformation("Exited Blazot request due to current rate limit exceeded state.");
+        return Enumerable.Empty<Content>();
+      }
+
+      // Get initial access token if empty.
+      if (string.IsNullOrWhiteSpace(_AuthService.AccessToken))
+      {
+        await _TransmissionsService.StartInitialWindowTimerAsync();
+
+        var (isSuccessStatusCode, _) = await _AuthService.GetAccessTokenAsync();
+        if (isSuccessStatusCode is null or false)
+          return Enumerable.Empty<Content>();
+      }
+
+      transmissions = await _TransmissionsService.GetHashtagTransmissionsAsync(tag, dateTimeOffset);
+
+      if (transmissions == null)
+        return Enumerable.Empty<Content>();
+    }
+    catch (Exception ex)
+    {
+      _Logger.LogError(ex, "Error fetching Blazot Hashtag Transmissions: {message}", ex.Message);
+    }
+
+    return _ContentConverter.ConvertToContent(transmissions, tag);
+  }
+}

--- a/src/TagzApp.Providers.Blazot/Configuration/BlazotClientConfiguration.cs
+++ b/src/TagzApp.Providers.Blazot/Configuration/BlazotClientConfiguration.cs
@@ -1,0 +1,16 @@
+﻿using TagzApp.Communication.Configuration;
+
+namespace TagzApp.Providers.Blazot.Configuration;
+
+public class BlazotClientConfiguration : HttpClientOptions
+{
+  /// <summary>
+  /// Declare the section name used.
+  /// </summary>
+  public const string AppSettingsSection = "providers:blazot";
+
+  /// <summary>
+  /// Blazot issued API Key.
+  /// </summary>
+  public string ApiKey { get; set; } = string.Empty;
+}

--- a/src/TagzApp.Providers.Blazot/Configuration/BlazotSettings.cs
+++ b/src/TagzApp.Providers.Blazot/Configuration/BlazotSettings.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TagzApp.Providers.Blazot.Configuration;
+internal class BlazotSettings
+{
+  /// <summary>
+  /// Declare the section name used.
+  /// </summary>
+  public const string AppSettingsSection = "providers:blazot";
+
+  /// <summary>
+  /// Blazot issued API Key.
+  /// </summary>
+  public string ApiKey { get; set; } = string.Empty;
+
+  /// <summary>
+  /// Blazot issued Secret Auth Key. This is only needed when making a request to get the access token at the auth endpoint.
+  /// </summary>
+  public string SecretAuthKey { get; set; } = string.Empty;
+
+  /// <summary>
+  /// The number of seconds in the rate limit window.
+  /// </summary>
+  public int WindowSeconds { get; set; }
+
+  /// <summary>
+  /// The number of requests the account allows within the window.
+  /// </summary>
+  public int WindowRequests { get; set; }
+}

--- a/src/TagzApp.Providers.Blazot/Constants/BlazotConstants.cs
+++ b/src/TagzApp.Providers.Blazot/Constants/BlazotConstants.cs
@@ -1,0 +1,16 @@
+﻿namespace TagzApp.Providers.Blazot.Constants;
+
+internal static class BlazotConstants
+{
+  /// <summary>
+  /// The base address for the Blazot API.
+  /// </summary>
+  public const string BaseAddress = "https://api.blazot.com";
+
+  /// <summary>
+  /// The (non-api) base address for the Blazot website.
+  /// </summary>
+  public const string BaseAppAddress = "https://blazot.com";
+  public const string ProviderId = "BLAZOT";
+  public const string DisplayName = "Blazot";
+}

--- a/src/TagzApp.Providers.Blazot/Converters/ContentConverter.cs
+++ b/src/TagzApp.Providers.Blazot/Converters/ContentConverter.cs
@@ -1,0 +1,118 @@
+﻿using Microsoft.Extensions.Logging;
+using TagzApp.Providers.Blazot.Constants;
+using TagzApp.Providers.Blazot.Formatters;
+using TagzApp.Providers.Blazot.Interfaces;
+using TagzApp.Providers.Blazot.Models;
+
+namespace TagzApp.Providers.Blazot.Converters;
+
+public class ContentConverter : IContentConverter
+{
+  private readonly ILogger<ContentConverter> _Logger;
+
+  public ContentConverter(ILogger<ContentConverter> logger)
+  {
+    _Logger = logger;
+  }
+
+  public IEnumerable<Content> ConvertToContent(List<Transmission>? transmissions, Hashtag tag)
+  {
+    if (transmissions is null || !transmissions.Any())
+      return Enumerable.Empty<Content>();
+
+    var outContent = new List<Content>();
+
+    foreach (var transmission in transmissions)
+    {
+      var content = BuildContentFromTransmission(transmission, tag);
+      if (content == null) continue;
+
+      outContent.Add(content);
+    }
+
+    return outContent;
+  }
+
+  private Content? BuildContentFromTransmission(Transmission? transmission, Hashtag? tag = null)
+  {
+    if (transmission is null) return null;
+    var author = transmission.Author;
+
+    try
+    {
+      var body = transmission.Body;
+      if (!string.IsNullOrWhiteSpace(body))
+      {
+        body = LinkFormatters.AddWebLinks(body);
+        body = LinkFormatters.AddHashTagLinks(body);
+        body = LinkFormatters.AddMentionLinks(body);
+      }
+
+      body = body.Replace("\n", "<br/>");
+
+      var content = new Content
+      {
+        Provider = BlazotConstants.ProviderId,
+        ProviderId = transmission.TransmissionId.ToString(),
+        Author = new Creator
+        {
+          DisplayName = author.DisplayName,
+          UserName = $"@{author.UserName}",
+          ProviderId = BlazotConstants.ProviderId,
+          ProfileImageUri = new Uri(author.ProfileImageUrl),
+          ProfileUri = new Uri(Path.Combine(BlazotConstants.BaseAppAddress, author.UserName).Replace(@"\", "/"))
+        },
+        SourceUri = new Uri(Path.Combine(BlazotConstants.BaseAppAddress, "transmission", transmission.TransmissionId.ToString()).Replace(@"\", "/")),
+        Text = body,
+        Timestamp = new DateTimeOffset(transmission.DateTransmitted, TimeSpan.Zero).ToLocalTime(),
+        HashtagSought = tag?.Text ?? string.Empty,
+        Type = ContentType.Message
+      };
+
+      var imageLinks = transmission.Media.Select(m => m.ImageUrl).ToList();
+      if (imageLinks.Any())
+      {
+        foreach (var link in imageLinks)
+        {
+          if (link == null) continue;
+
+          content.PreviewCard = new Card
+          {
+            ImageUri = new Uri(link)
+          };
+        }
+      }
+
+      var videoLinks = transmission.Media.Select(m => m.VideoCover).ToList();
+      if (videoLinks.Any())
+      {
+        foreach (var link in videoLinks)
+        {
+          if (link == null) continue;
+
+          content.PreviewCard = new Card
+          {
+            ImageUri = new Uri(link)
+          };
+        }
+      }
+
+      if (!string.IsNullOrWhiteSpace(transmission.WebLink.ImageUrl))
+      {
+        content.PreviewCard = new Card
+        {
+          AltText = transmission.WebLink.Description,
+          ImageUri = new Uri(transmission.WebLink.ImageUrl)
+        };
+      }
+
+      return content;
+    }
+    catch (Exception ex)
+    {
+      _Logger.LogError(ex, "{message}", ex.Message);
+    }
+
+    return null;
+  }
+}

--- a/src/TagzApp.Providers.Blazot/Events/AuthEvents.cs
+++ b/src/TagzApp.Providers.Blazot/Events/AuthEvents.cs
@@ -1,0 +1,15 @@
+﻿namespace TagzApp.Providers.Blazot.Events;
+
+internal interface IAuthEvents 
+{
+  event EventHandler AccessTokenUpdated;
+
+  void NotifyAccessTokenUpdated();
+}
+
+internal class AuthEvents : IAuthEvents
+{
+  public event EventHandler AccessTokenUpdated;
+
+  public void NotifyAccessTokenUpdated() => AccessTokenUpdated.Invoke(this, EventArgs.Empty);
+}

--- a/src/TagzApp.Providers.Blazot/Formatters/LinkFormatters.cs
+++ b/src/TagzApp.Providers.Blazot/Formatters/LinkFormatters.cs
@@ -1,0 +1,44 @@
+﻿using System.Text.RegularExpressions;
+
+namespace TagzApp.Providers.Blazot.Formatters;
+
+internal static class LinkFormatters
+{
+  private static Regex LinkRegex => new(@"(?:(?:https?):\/\/)?[\w/\.-]+(?<!\.)(\.)(?!\.)[a-zA-Z]+(?<!\?)[a-zA-Z0-9/\-&?.=%#_]+(?<!\.)");
+  private static Regex HashTagRegex => new(@"(^|[^&\p{L}\p{M}\p{Nd}_\u200c\u200d\ua67e\u05be\u05f3\u05f4\u309b\u309c\u30a0\u30fb\u3003\u0f0b\u0f0c\u00b7])(#|\uFF03)(?!\uFE0F|\u20E3)([\p{L}\p{M}\p{Nd}_\u200c\u200d\ua67e\u05be\u05f3\u05f4\u309b\u309c\u30a0\u30fb\u3003\u0f0b\u0f0c\u00b7]*[\p{L}\p{M}][\p{L}\p{M}\p{Nd}_\u200c\u200d\ua67e\u05be\u05f3\u05f4\u309b\u309c\u30a0\u30fb\u3003\u0f0b\u0f0c\u00b7]*)");
+  private static Regex UserMentionRegex => new(@"\B@\w+");
+
+  public static string AddHashTagLinks(string bodyText)
+  {
+    return HashTagRegex.Replace(bodyText, delegate(Match m)
+    {
+      var noHash = m.Value.Trim().TrimStart('#');
+      var hashed = m.Value.Trim();
+      return $" <a class=\"b-hashtag-link\" href=\"https://blazot.com/hashtag/{noHash}\">{hashed}</a>";
+    });
+  }
+
+  public static string AddWebLinks(string bodyText)
+  {
+    return LinkRegex.Replace(bodyText, delegate(Match m)
+    {
+      var fullLink = AddHttpIfMissing(m.Value);
+      return $"<a class=\"b-url-link\" target=\"_blank\" href=\"{fullLink}\">{m.Value}</a>";
+    });
+  }
+
+  public static string AddMentionLinks(string bodyText) =>
+    UserMentionRegex.Replace(bodyText, m => $"<a class=\"b-url-link\" target=\"_blank\" href=\"https://blazot.com/{m.Value.Trim().TrimStart('@')}\">{m.Value}</a>");
+
+  private static string AddHttpIfMissing(string url)
+  {
+    if (string.IsNullOrEmpty(url))
+      return url;
+
+    url = url.Trim();
+    if (!url.StartsWith("http://") && !url.StartsWith("https://"))
+      return $"http://{url}";
+
+    return url;
+  }
+}

--- a/src/TagzApp.Providers.Blazot/Interfaces/IAuthService.cs
+++ b/src/TagzApp.Providers.Blazot/Interfaces/IAuthService.cs
@@ -1,0 +1,9 @@
+﻿using System.Net;
+
+namespace TagzApp.Providers.Blazot.Interfaces;
+
+internal interface IAuthService
+{
+  string? AccessToken { get; }
+  Task<(bool? isSuccessStatusCode, HttpStatusCode? httpStatusCode)> GetAccessTokenAsync();
+}

--- a/src/TagzApp.Providers.Blazot/Interfaces/IContentConverter.cs
+++ b/src/TagzApp.Providers.Blazot/Interfaces/IContentConverter.cs
@@ -1,0 +1,8 @@
+﻿using TagzApp.Providers.Blazot.Models;
+
+namespace TagzApp.Providers.Blazot.Interfaces;
+
+internal interface IContentConverter
+{
+  IEnumerable<Content> ConvertToContent(List<Transmission>? transmissions, Hashtag tag);
+}

--- a/src/TagzApp.Providers.Blazot/Interfaces/ITransmissionsService.cs
+++ b/src/TagzApp.Providers.Blazot/Interfaces/ITransmissionsService.cs
@@ -1,0 +1,10 @@
+﻿using TagzApp.Providers.Blazot.Models;
+
+namespace TagzApp.Providers.Blazot.Interfaces;
+
+internal interface ITransmissionsService
+{
+  bool HasMadeTooManyRequests { get; }
+  Task StartInitialWindowTimerAsync();
+  Task<List<Transmission>?> GetHashtagTransmissionsAsync(Hashtag tag, DateTimeOffset dateTimeOffset);
+}

--- a/src/TagzApp.Providers.Blazot/Models/Author.cs
+++ b/src/TagzApp.Providers.Blazot/Models/Author.cs
@@ -1,0 +1,9 @@
+﻿namespace TagzApp.Providers.Blazot.Models;
+public class Author
+{
+  public string UserName { get; set; }
+  public string DisplayName { get; set; }
+  public bool IsSubscriber { get; set; }
+  public int? SubscriptionLevel { get; set; }
+  public string ProfileImageUrl { get; set; }
+}

--- a/src/TagzApp.Providers.Blazot/Models/Media.cs
+++ b/src/TagzApp.Providers.Blazot/Models/Media.cs
@@ -1,0 +1,7 @@
+﻿namespace TagzApp.Providers.Blazot.Models;
+public class Media
+{
+  public string? VideoUrl { get; set; }
+  public string? VideoCover { get; set; }
+  public string? ImageUrl { get; set; }
+}

--- a/src/TagzApp.Providers.Blazot/Models/Token.cs
+++ b/src/TagzApp.Providers.Blazot/Models/Token.cs
@@ -1,0 +1,6 @@
+﻿namespace TagzApp.Providers.Blazot.Models;
+internal class Token
+{
+  public string? TokenType { get; set; }
+  public string? AccessToken { get; set; }
+}

--- a/src/TagzApp.Providers.Blazot/Models/Transmission.cs
+++ b/src/TagzApp.Providers.Blazot/Models/Transmission.cs
@@ -1,0 +1,38 @@
+﻿namespace TagzApp.Providers.Blazot.Models;
+
+  public class Transmission
+  {
+    /// <summary>
+    /// The unique identifier for the transmission.
+    /// </summary>
+    public Guid TransmissionId { get; set; }
+
+    /// <summary>
+    /// The unique identifier for the parent transmission that this transmission is a response to.
+    /// </summary>
+    public Guid? ParentItemId { get; set; }
+
+    /// <summary>
+    /// The UTC date/time this transmission was transmitted.
+    /// </summary>
+    public DateTime DateTransmitted { get; set; }
+
+    /// <summary>
+    /// The transmission text.
+    /// </summary>
+    public string Body { get; set; }
+
+    /// <summary>
+    /// The author object.
+    /// </summary>
+    public Author Author { get; set; }
+
+    /// <summary>
+    /// Video or images within this transmission.
+    /// </summary>
+    public List<Media> Media { get; set; }
+
+    public WebLink WebLink { get; set; }
+
+    public Transmission RelayedTransmission { get; set; }
+}

--- a/src/TagzApp.Providers.Blazot/Models/WebLink.cs
+++ b/src/TagzApp.Providers.Blazot/Models/WebLink.cs
@@ -1,0 +1,8 @@
+﻿namespace TagzApp.Providers.Blazot.Models;
+public class WebLink
+{
+  public string LinkUrl { get; set; }
+  public string ImageUrl { get; set; }
+  public string Title { get; set; }
+  public string Description { get; set; }
+}

--- a/src/TagzApp.Providers.Blazot/ReadMe.md
+++ b/src/TagzApp.Providers.Blazot/ReadMe.md
@@ -1,0 +1,11 @@
+﻿# Blazot Provider
+API Documentation is available at https://developers.blazot.com/docs/api/v1
+
+### Key Points
+- The first thing you need to do is create a user account (<span style="color:orange">⚠️not company - read below</span>) at https://blazot.com. 
+	- If you're creating an account for a company, that should be created as a "Site" after creating and logging in with your personal user account. If you use the desired company username as a user, it won't be available as a Site.
+- The API key and Secret Auth Key is available in the user's Configuration page (top right menu) or Site's Configuration page after logging into https://blazot.com.
+- The API keys then need added to the TagzApp app settings, ideally in your local secret store or Azure Key Vault.
+- The Blazot provider uses those keys to fetch the access token and renews that token as needed. The Secret Auth Token should only be used to get the access token.
+- If your keys or token are compromised, just regenerate your keys on the Blazot Configuration page.
+- The current default rate limit is 5 requests per 15 minute window for users without a Blazot subscription. This will likely increase as the site grows, but there isn't a real need to make more requests than that at the moment.

--- a/src/TagzApp.Providers.Blazot/Services/AuthService.cs
+++ b/src/TagzApp.Providers.Blazot/Services/AuthService.cs
@@ -1,0 +1,75 @@
+﻿using System.Net;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Configuration;
+using TagzApp.Providers.Blazot.Constants;
+using TagzApp.Providers.Blazot.Events;
+using TagzApp.Providers.Blazot.Interfaces;
+using TagzApp.Providers.Blazot.Models;
+using TagzApp.Providers.Blazot.Configuration;
+
+namespace TagzApp.Providers.Blazot.Services;
+
+internal class AuthService : IAuthService
+{
+  private readonly string? _ApiKey;
+  private readonly string? _SecretAuthKey;
+  private readonly HttpClient _HttpClient;
+  private readonly IAuthEvents _AuthEvents;
+  private readonly ILogger<AuthService> _Logger;
+
+  public AuthService(ILogger<AuthService> logger, IHttpClientFactory httpClientFactory, IAuthEvents authEvents, IConfiguration configuration)
+  {
+    _Logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    _HttpClient = httpClientFactory.CreateClient(nameof(BlazotProvider));
+    _AuthEvents = authEvents ?? throw new ArgumentNullException(nameof(authEvents));
+
+    var settings = configuration.GetSection(BlazotSettings.AppSettingsSection).Get<BlazotSettings>();
+    _ApiKey = settings?.ApiKey ?? throw new ArgumentNullException(nameof(settings));
+    _HttpClient.DefaultRequestHeaders.Add("x-api-key", _ApiKey);
+    _SecretAuthKey = settings.SecretAuthKey;
+  }
+
+  public string? AccessToken { get; private set; }
+
+  public async Task<(bool? isSuccessStatusCode, HttpStatusCode? httpStatusCode)> GetAccessTokenAsync()
+  {
+    HttpResponseMessage? response = null;
+
+    try
+    {
+      if (string.IsNullOrEmpty(_ApiKey))
+        throw new InvalidOperationException("Blazot API Key is missing from app settings.");
+
+      if (string.IsNullOrWhiteSpace(_SecretAuthKey))
+        throw new InvalidOperationException("Blazot Secret Auth Key is missing from app settings.");
+
+      var address = Path.Combine(BlazotConstants.BaseAddress, "auth/token").Replace(@"\", "/");
+      var uri = new Uri(address);
+
+      _HttpClient.DefaultRequestHeaders.Add("x-secret-auth-key", _SecretAuthKey);
+      response = await _HttpClient.GetAsync(uri);
+      if (response.IsSuccessStatusCode)
+      {
+        var serializedResult = await response.Content.ReadAsStringAsync();
+        var token = JsonSerializer.Deserialize<Token>(serializedResult, new JsonSerializerOptions {PropertyNameCaseInsensitive = true});
+        AccessToken = $"Bearer {token?.AccessToken}";
+        _AuthEvents.NotifyAccessTokenUpdated();
+      }
+      else
+      {
+        _Logger.LogWarning("Blazot access token request failed: {reason}", response.ReasonPhrase);
+      }
+    }
+    catch (Exception ex)
+    {
+      _Logger.LogError(ex, "Failed to get Blazot Access Token: {message}", ex.Message);
+    }
+    finally
+    {
+      _HttpClient.DefaultRequestHeaders.Remove("x-secret-auth-key");
+    }
+
+    return (response?.IsSuccessStatusCode, response?.StatusCode);
+  }
+}

--- a/src/TagzApp.Providers.Blazot/Services/HashtagTransmissionsService.cs
+++ b/src/TagzApp.Providers.Blazot/Services/HashtagTransmissionsService.cs
@@ -1,0 +1,150 @@
+﻿using System.Net;
+using System.Timers;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Configuration;
+using TagzApp.Providers.Blazot.Configuration;
+using TagzApp.Providers.Blazot.Constants;
+using TagzApp.Providers.Blazot.Events;
+using TagzApp.Providers.Blazot.Interfaces;
+using TagzApp.Providers.Blazot.Models;
+using Timer = System.Timers.Timer;
+
+namespace TagzApp.Providers.Blazot.Services;
+
+internal class HashtagTransmissionsService : ITransmissionsService, IDisposable
+{
+  private readonly int _WindowSeconds;
+  private readonly Timer? _WindowTimer;
+  private readonly HttpClient _HttpClient;
+  private readonly IAuthService _AuthService;
+  private readonly IAuthEvents _AuthEvents;
+  private DateTime _SinceDate = DateTime.MinValue;
+  private readonly ILogger<HashtagTransmissionsService> _Logger;
+
+  public HashtagTransmissionsService(IConfiguration configuration, ILogger<HashtagTransmissionsService> logger,
+    IHttpClientFactory httpClientFactory, IAuthEvents authEvents, IAuthService authService)
+  {
+    _Logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    _HttpClient = httpClientFactory.CreateClient(nameof(BlazotProvider));
+    _AuthService = authService ?? throw new ArgumentNullException(nameof(authService));
+
+    var settings = configuration.GetSection(BlazotSettings.AppSettingsSection).Get<BlazotSettings>();
+    _WindowSeconds = settings?.WindowSeconds ?? throw new ArgumentNullException(nameof(settings));
+
+    _WindowTimer = new Timer { Interval = TimeSpan.FromSeconds(_WindowSeconds).TotalMilliseconds, AutoReset = true };
+    _WindowTimer.Elapsed += HandleWindowTimerElapsed;
+
+    _AuthEvents = authEvents ?? throw new ArgumentNullException(nameof(authEvents));
+    _AuthEvents.AccessTokenUpdated += UpdateAuthorizationHeader;
+  }
+
+  public bool HasMadeTooManyRequests { get; private set; }
+
+  public Task StartInitialWindowTimerAsync()
+  {
+    _WindowTimer?.Start();
+    return Task.CompletedTask;
+  }
+
+  public async Task<List<Transmission>?> GetHashtagTransmissionsAsync(Hashtag tag, DateTimeOffset dateTimeOffset)
+  {
+    Exception? exception = null;
+    List<Transmission>? transmissions = null;
+    var maxTryCount = 4;
+
+    if (_SinceDate == DateTime.MinValue)
+      _SinceDate = dateTimeOffset.UtcDateTime;
+
+    for (var i = 0; i < maxTryCount; i++)
+    {
+      try
+      {
+        var response = await RequestHashtagTransmissionsAsync(tag);
+        if (response == null)
+          throw new InvalidOperationException("Null response from Blazot.");
+
+        var serializedResult = await response.Content.ReadAsStringAsync();
+        transmissions = JsonSerializer.Deserialize<List<Transmission>>(serializedResult, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        if (transmissions?.Count > 0)
+          _SinceDate = transmissions.OrderByDescending(p => p.DateTransmitted).First().DateTransmitted;
+
+        exception = null;
+        break;
+      }
+      catch (UnauthorizedAccessException ex)
+      {
+        _Logger.LogInformation("Unauthorized request to Blazot. The app will attempt to refresh the access token. Attempt {count} of {total}", i + 1, maxTryCount);
+        // If token has expired, request a new one.
+        var response = await _AuthService.GetAccessTokenAsync();
+        if (response.isSuccessStatusCode is null or false)
+          break;
+      }
+      catch (InvalidOperationException ex) when (ex.Message.Contains("Rate limit exceeded"))
+      {
+        HasMadeTooManyRequests = true;
+        var retrySeconds = _WindowTimer != null ? (int)TimeSpan.FromMilliseconds(_WindowTimer.Interval).TotalSeconds : _WindowSeconds;
+        _Logger.LogWarning("Blazot rate limit exceeded. Will try again in {seconds} seconds", retrySeconds);
+        break;
+      }
+      catch (Exception ex)
+      {
+        _Logger.LogError(ex, "Error fetching Blazot hashtag transmissions on attempt {count} of {total}: {message}", i, maxTryCount, ex.Message);
+        await Task.Delay(3000);
+      }
+    }
+
+    if (exception != null)
+      throw exception;
+
+    return transmissions;
+  }
+
+  private async Task<HttpResponseMessage> RequestHashtagTransmissionsAsync(Hashtag tag)
+  {
+    var uri = new Uri(Path.Combine(BlazotConstants.BaseAddress, $"hashtag?t={tag.Text.TrimStart('#')}&takeCount=20&sinceDate={_SinceDate.ToString("M/dd/yyyy H:mm:ss.fffffff tt")}").Replace(@"\", "/"));
+    var response = await _HttpClient.GetAsync(uri);
+    if (response.StatusCode == HttpStatusCode.Unauthorized)
+      throw new UnauthorizedAccessException("Request to fetch results from Blazot was unauthorized.");
+
+    if (response.StatusCode == HttpStatusCode.TooManyRequests)
+    {
+      await UpdateWindowTimerWithRetryHeaderAsync(response);
+      throw new InvalidOperationException("Rate limit exceeded.");
+    }
+
+    if (response.StatusCode != HttpStatusCode.OK)
+      throw new InvalidOperationException($"Blazot API returned a non-OK response: {response.ReasonPhrase}");
+
+    return response;
+  }
+
+  private Task<double> UpdateWindowTimerWithRetryHeaderAsync(HttpResponseMessage? response)
+  {
+    var secondsUntilReset = response?.Headers.RetryAfter;
+    if (secondsUntilReset == null)
+      return Task.FromResult((double)_WindowSeconds);
+
+    var isInt = int.TryParse(secondsUntilReset.ToString(), out var retrySeconds);
+    if (isInt && _WindowTimer != null)
+      _WindowTimer.Interval = TimeSpan.FromSeconds(retrySeconds).TotalMilliseconds;
+
+    return Task.FromResult(isInt ? (double)retrySeconds : _WindowSeconds);
+  }
+
+  private void HandleWindowTimerElapsed(object sender, ElapsedEventArgs args) =>
+    HasMadeTooManyRequests = false;
+
+  private void UpdateAuthorizationHeader(object sender, EventArgs args)
+  {
+    _HttpClient.DefaultRequestHeaders.Remove("Authorization");
+    _HttpClient.DefaultRequestHeaders.Add("Authorization", _AuthService.AccessToken);
+  }
+
+  public void Dispose()
+  {
+    _WindowTimer?.Dispose();
+    _AuthEvents.AccessTokenUpdated -= UpdateAuthorizationHeader;
+  }
+}

--- a/src/TagzApp.Providers.Blazot/StartBlazot.cs
+++ b/src/TagzApp.Providers.Blazot/StartBlazot.cs
@@ -1,0 +1,55 @@
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using TagzApp.Common.Exceptions;
+using TagzApp.Communication.Extensions;
+using TagzApp.Providers.Blazot.Configuration;
+using TagzApp.Providers.Blazot.Constants;
+using TagzApp.Providers.Blazot.Converters;
+using TagzApp.Providers.Blazot.Events;
+using TagzApp.Providers.Blazot.Interfaces;
+using TagzApp.Providers.Blazot.Services;
+
+namespace TagzApp.Providers.Blazot;
+
+public class StartBlazot : IConfigureProvider
+{
+  private readonly ILogger<StartBlazot> _Logger;
+
+  public StartBlazot() { }
+  public StartBlazot(ILogger<StartBlazot> logger)
+  {
+    _Logger = logger ?? throw new ArgumentNullException(nameof(logger));
+  }
+
+  public IServiceCollection RegisterServices(IServiceCollection services, IConfiguration configuration)
+  {
+    IConfigurationSection config;
+
+    try
+    {
+      config = configuration.GetSection(BlazotClientConfiguration.AppSettingsSection);
+      services.Configure<BlazotClientConfiguration>(config);
+    }
+    catch (Exception ex)
+    {
+      _Logger.LogError(ex, "Error configuring Blazot: {message}", ex.Message);
+      throw new InvalidConfigurationException(ex.Message, BlazotClientConfiguration.AppSettingsSection);
+    }
+
+    var settings = config.Get<BlazotClientConfiguration>();
+
+    if (string.IsNullOrWhiteSpace(settings?.BaseAddress?.ToString()) || string.IsNullOrWhiteSpace(settings.ApiKey))
+      return services;
+
+    services.AddSingleton(configuration);
+    services.AddHttpClient<ISocialMediaProvider, BlazotProvider, BlazotClientConfiguration>(configuration, BlazotClientConfiguration.AppSettingsSection);
+    services.AddTransient<ISocialMediaProvider, BlazotProvider>();
+    services.AddSingleton<IContentConverter, ContentConverter>();
+    services.AddSingleton<ITransmissionsService, HashtagTransmissionsService>();
+    services.AddSingleton<IAuthService, AuthService>();
+    services.AddSingleton<IAuthEvents, AuthEvents>();
+
+    return services;
+  }
+}

--- a/src/TagzApp.Providers.Blazot/TagzApp.Providers.Blazot.csproj
+++ b/src/TagzApp.Providers.Blazot/TagzApp.Providers.Blazot.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
+
+	<PropertyGroup>
+		<TargetFramework>net7.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+		<GenerateEmbeddedFilesManifest>true</GenerateEmbeddedFilesManifest>
+	</PropertyGroup>
+
+	<ItemGroup>
+	  <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
+	  <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
+	  <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
+	  <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="7.0.0" />
+	  <PackageReference Include="System.Net.Http.Json" Version="7.0.1" />
+	  <ProjectReference Include="..\TagzApp.Common\TagzApp.Common.csproj" />
+	  <ProjectReference Include="..\TagzApp.Communication\TagzApp.Communication.csproj" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<EmbeddedResource Include="wwwroot\**\*" />
+		<Content Update="**\*.cshtml" Pack="false" />
+	</ItemGroup>
+
+</Project>

--- a/src/TagzApp.Providers.Blazot/wwwroot/css/blazot.css
+++ b/src/TagzApp.Providers.Blazot/wwwroot/css/blazot.css
@@ -1,0 +1,16 @@
+﻿/* Extends bootstrap icons to include a Blazot icon in the card item. */
+.bi-blazot {
+    width: 24px;
+    height: 36px;
+    background-position: right 0 top 0.06rem;
+    background-repeat: no-repeat;
+    background-image: url('data:image/svg+xml;utf8, <svg version="1.1" id="BlazotRocketOnlyIcon" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 42 42" enable-background="new 0 0 42 42" xml:space="preserve" fill="currentColor"><g id="Rocket"><path d="M28.4,26c1-0.7,2-1.6,3.1-2.7c8.2-8.5,6.7-20.1,6.7-20.1s-11.2-1.5-19.4,7c-1,1-1.8,2.1-2.6,3.1l-7,0.3l-5.5,9l8.4,1.5c-0.1,0.4-0.1,0.7-0.2,1.1l5,5.2c0.3-0.1,0.7-0.1,1-0.2l1.5,8.7l8.6-5.7L28.4,26zM25.5,16.4c-2.1-2.2-2.1-5.8,0-8s5.6-2.2,7.7,0s2.1,5.8,0,8S27.7,18.6,25.5,16.4z"/></g><g id="Flame"><path d="M13.4,28.9c-1.7-1.7-4-2.1-6,0c-2,2.1-3.8,6.4-2.8,9.2c2.9,1,6.8-0.8,8.8-2.9C15.4,33,15,30.6,13.4,28.9zM6.7,35.8c-0.5-1.9,0.7-4.9,2.1-6.3c1.4-1.5,3-1.3,4.1-0.2c1.1,1.1,1.3,2.8-0.2,4.3C11.4,35.1,8.7,36.4,6.7,35.8z"/></g></svg>');
+}
+
+/* Extends bootstrap icons to include a Blazot icon in the modal. */
+div.modal .bi-blazot {
+    display: inline-block;
+    vertical-align: middle;
+    width: 24px;
+    height: 26px;
+}

--- a/src/TagzApp.Web/Pages/Shared/_WaterfallLayout.cshtml
+++ b/src/TagzApp.Web/Pages/Shared/_WaterfallLayout.cshtml
@@ -10,7 +10,8 @@
 	<link rel="stylesheet" href="~/lib/bootstrap/dist/css/bootstrap.min.css" />
 	<link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />
 	<link rel="stylesheet" href="~/TagzApp.Web.styles.css" asp-append-version="true" />
-	<link rel="stylesheet" href="~/lib/bootstrap-icons/font/bootstrap-icons.min.css" />
+    <link rel="stylesheet" href="~/lib/bootstrap-icons/font/bootstrap-icons.min.css" />
+    <link rel="stylesheet" href="_content/TagzApp.Providers.Blazot/css/blazot.css" />
 </head>
 <body style="overflow-y: hidden;">
 

--- a/src/TagzApp.Web/TagzApp.Web.csproj
+++ b/src/TagzApp.Web/TagzApp.Web.csproj
@@ -13,6 +13,7 @@
     <ProjectReference Include="..\TagzApp.Providers.Mastodon\TagzApp.Providers.Mastodon.csproj" />
     <ProjectReference Include="..\TagzApp.Providers.TwitchChat\TagzApp.Providers.TwitchChat.csproj" />
     <ProjectReference Include="..\TagzApp.Providers.Twitter\TagzApp.Providers.Twitter.csproj" />
+    <ProjectReference Include="..\TagzApp.Providers.Blazot\TagzApp.Providers.Blazot.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/TagzApp.Web/appsettings.json
+++ b/src/TagzApp.Web/appsettings.json
@@ -25,6 +25,14 @@
       "ApiSecretKey": "******[Add to Local Secret Store]******",
       "AccessToken": "******[Add to Local Secret Store]******",
       "AccessTokenSecret": "******[Add to Local Secret Store]******"
+    },
+    "blazot": {
+      "BaseAddress": "https://api.blazot.com",
+      "Timeout": "00:03:00",
+      "ApiKey": "******[Add to Local Secret Store]******",
+      "SecretAuthKey": "******[Add to Local Secret Store]******",
+      "WindowSeconds": 900,
+      "WindowRequests": 5 
     }
   },
   "HttpPolicies": {

--- a/src/TagzApp.sln
+++ b/src/TagzApp.sln
@@ -37,6 +37,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TagzApp.Providers.Twitter",
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TagzApp.Providers.TwitchChat", "TagzApp.Providers.TwitchChat\TagzApp.Providers.TwitchChat.csproj", "{8D0F679C-307A-4861-8B78-E7BCF95A5750}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TagzApp.Providers.Blazot", "TagzApp.Providers.Blazot\TagzApp.Providers.Blazot.csproj", "{B19CCF63-B77D-4FF0-9F90-D7AB65423748}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -79,6 +81,10 @@ Global
 		{8D0F679C-307A-4861-8B78-E7BCF95A5750}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8D0F679C-307A-4861-8B78-E7BCF95A5750}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8D0F679C-307A-4861-8B78-E7BCF95A5750}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B19CCF63-B77D-4FF0-9F90-D7AB65423748}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B19CCF63-B77D-4FF0-9F90-D7AB65423748}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B19CCF63-B77D-4FF0-9F90-D7AB65423748}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B19CCF63-B77D-4FF0-9F90-D7AB65423748}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -93,6 +99,7 @@ Global
 		{F4257494-6B73-4052-B34E-8212CDFA3E37} = {370455D5-6EA6-44C1-B315-B621F7B6A954}
 		{65459852-E2D6-47B9-911F-D3E09BD12816} = {99E0BB3F-9591-4C7A-A8EE-C54B0C3DE7A5}
 		{8D0F679C-307A-4861-8B78-E7BCF95A5750} = {99E0BB3F-9591-4C7A-A8EE-C54B0C3DE7A5}
+		{B19CCF63-B77D-4FF0-9F90-D7AB65423748} = {99E0BB3F-9591-4C7A-A8EE-C54B0C3DE7A5}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {F2AD77A5-5B2D-41FC-AD37-8EF8A4E54410}


### PR DESCRIPTION
Added a provider for a new social network I've been building at https://blazot.com. Blazot is a Blazor WASM based social network, with apps built in MAUI-Blazor. As you'll see in the PR, the API is located at https://api.blazot.com. Since Blazot doesn't have a Bootstrap icon, a css file is referenced in the waterfall layout page.