### PR TITLE
Add explicit write permission for package registry

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -61,6 +61,8 @@ jobs:
         name: 'Create docker image for Web'
         runs-on: ubuntu-latest
         needs: [playwright]
+        permissions:
+          packages: write
         steps:
           - uses: actions/checkout@v3
           


### PR DESCRIPTION
Resolves #116 . This bug doesn't seem to impact FritzAndFriends, but it does for the csharpfritz repo:
https://github.com/csharpfritz/TagzApp/actions/runs/5893531438

![image](https://github.com/FritzAndFriends/TagzApp/assets/4265693/57205fd7-e69c-4e61-9604-fddff24428e1)
