### PR TITLE
Add skippable fact and user secrets for YouTube tests.

### DIFF
--- a/src/TagzApp.Providers.Youtube/Configuration/YoutubeConfiguration.cs
+++ b/src/TagzApp.Providers.Youtube/Configuration/YoutubeConfiguration.cs
@@ -1,4 +1,6 @@
-﻿namespace TagzApp.Providers.Youtube.Configuration;
+﻿using Google.Apis.YouTube.v3;
+
+namespace TagzApp.Providers.Youtube.Configuration;
 
 /// <summary>
 /// Defines the Youtube configuration
@@ -14,4 +16,8 @@ public class YoutubeConfiguration
 	/// YouTube assigned API key
 	/// </summary>
 	public required string ApiKey { get; set; }
+
+	public SearchResource.ListRequest.SafeSearchEnum SafeSearch { get; set; } = SearchResource.ListRequest.SafeSearchEnum.Moderate;
+
+	public long MaxResults { get; set; } = 50;
 }

--- a/src/TagzApp.Providers.Youtube/YoutubeProvider.cs
+++ b/src/TagzApp.Providers.Youtube/YoutubeProvider.cs
@@ -30,8 +30,8 @@ internal class YoutubeProvider : ISocialMediaProvider
 		var searchListRequest = youtubeService.Search.List("snippet");
 		searchListRequest.Q = tag.Text;
 		searchListRequest.Order = SearchResource.ListRequest.OrderEnum.Relevance;
-		searchListRequest.SafeSearch = SearchResource.ListRequest.SafeSearchEnum.Moderate;
-		searchListRequest.MaxResults = 50;
+		searchListRequest.SafeSearch = _Configuration.SafeSearch;
+		searchListRequest.MaxResults = _Configuration.MaxResults;
 
 		var searchListResponse = await searchListRequest.ExecuteAsync();
 

--- a/src/TagzApp.UnitTest/TagzApp.UnitTest.csproj
+++ b/src/TagzApp.UnitTest/TagzApp.UnitTest.csproj
@@ -1,9 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <UserSecretsId>f5d54418-d0d8-4854-8a2f-d0f4cd7ca7c3</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>
@@ -16,6 +17,12 @@
     </PackageReference>
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="7.0.0" />
+  </ItemGroup>
+  
   <ItemGroup>
     <ProjectReference Include="..\TagzApp.Common\TagzApp.Common.csproj" />
     <ProjectReference Include="..\TagzApp.Providers.Mastodon\TagzApp.Providers.Mastodon.csproj" />


### PR DESCRIPTION
Add MaxResults and SafeSearch options to configuration. (MaxResults is set to 1 for testing.)
The youtube key (and any other config) can be added to the usersecrets files associated with the `TagzApp.UnitTest` project.
The config matches the main appsetting.json such as:
```json
{
	"providers": {
		"youtube": {
			"ApiKey": "my-random-key"
		}
	}
}
```
If there is no key, then the unit test will be skipped, otherwise they will execute. This allows them to skip on the build server, but execute locally while developing, without having to change the code attributes, or potentially leaking API keys.