### PR TITLE
add: Better handling of environment values in docker-compose usage

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,18 @@
+# docker compose and/or something doesn't like ':' in keys!
+# According to a comment on a SO question's comment
+# (https://stackoverflow.com/questions/47827887/bash-zsh-export-environment-variable-with-name-containing-a-colon)
+# this works in dotnet core! (not tested myself!)
+# PLEASE don't use these kind of special characters in keys!
+
+# providers:mastadon
+providers__mastodon__BaseAddress=https://example.com
+
+# providers:youtube
+providers__youtube__ApiKey=
+
+# providers:twitter
+providers__twitter__DefaultHeaders__Authorization=Bearer $TOKEN
+providers__twitter__ApiKey=
+providers__twitter__ApiSecretKey=
+providers__twitter__AccessToken=
+providers__twitter__AccessTokenSecret=

--- a/.env.local
+++ b/.env.local
@@ -1,0 +1,18 @@
+# docker compose and/or something doesn't like ':' in keys!
+# According to a comment on a SO question's comment
+# (https://stackoverflow.com/questions/47827887/bash-zsh-export-environment-variable-with-name-containing-a-colon)
+# this works in dotnet core! (not tested myself!)
+# PLEASE don't use these kind of special characters in keys!
+
+# providers:mastadon
+providers__mastodon__BaseAddress=https://example-local.com
+
+# providers:youtube
+providers__youtube__ApiKey=
+
+# providers:twitter
+providers__twitter__DefaultHeaders__Authorization=Bearer $TOKEN
+providers__twitter__ApiKey=
+providers__twitter__ApiSecretKey=
+providers__twitter__AccessToken=
+providers__twitter__AccessTokenSecret=

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,4 +1,4 @@
-version: '3.7'
+version: "3.7"
 services:
   web:
     container_name: tagzapp.web
@@ -8,12 +8,7 @@ services:
       context: .
     ports:
       - "80" # runs on a random local port. Change to "8080:80" if you want to run on localhost:8080
-
-    # environment:
-    # - providers:mastodon:BaseAddress=https://example.com
-    # - providers:youtube:ApiKey=
-    # - providers:twitter:DefaultHeaders:Authorization=Bearer $TOKEN
-    # - providers:twitter:ApiKey=
-    # - providers:twitter:ApiSecretKey=
-    # - providers:twitter:AccessToken=
-    # - providers:twitter:AccessTokenSecret=
+    env_file:
+      # when .env values are used in this docker-compose file like 'hostname: $hostname' for example it is strongly recommended to inject them by referencing them like 'docker compose up --env-file .env' or 'docker compose up --env-file .env.local'
+      - .env
+      - .env.local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.7'
+version: "3.7"
 services:
   web:
     container_name: tagzapp.web
@@ -6,10 +6,6 @@ services:
     image: ghcr.io/fritzandfriends/tagzapp:latest
     ports:
       - "80" # runs on a random local port. Change to "8080:80" if you want to run on localhost:8080
-    # environment:
-    # - providers:youtube:ApiKey=
-    # - providers:twitter:DefaultHeaders:Authorization=Bearer $TOKEN
-    # - providers:twitter:ApiKey=
-    # - providers:twitter:ApiSecretKey=
-    # - providers:twitter:AccessToken=
-    # - providers:twitter:AccessTokenSecret=
+    env_file:
+      # when .env values are used in this docker-compose file like 'hostname: $hostname' for example it is strongly recommended to inject them by referencing them like 'docker compose up --env-file .env' or 'docker compose up --env-file .env.local'
+      - .env


### PR DESCRIPTION
Added better handling of environment variables in `docker-compose.yaml` files especially when there are different values for local testing instances.

I also added some light in-file documentation for the usage of environment values in the `.env` files. 

Note: Please also read my in-file comments about `:` usage in environment keys. 

