### PR TITLE
created first TODO for testing todo-to-issue GitHub Action

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+
+indent_size = 2
+indent_style = tab
+tab_width = 2
+end_of_line = lf
+
+[*.{yml,yaml}]
+indent_style = space

--- a/.github/workflows/dodos-to-issues.yml
+++ b/.github/workflows/dodos-to-issues.yml
@@ -1,0 +1,16 @@
+name: Create GitHub Issues from TODOs, FIXMEs, etc.
+
+on:
+  push:
+    branches: ["Stelzi79/TODOs_as_GHIssues"]
+
+jobs:
+  create_issues:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: "actions/checkout@v3"
+      - name: "TODO to Issue"
+        # See https://github.com/marketplace/actions/todo-to-issue for more configuration options
+        uses: "alstr/todo-to-issue-action@v4"
+        with:
+          IDENTIFIERS: '[{"name": "TODO", "labels": ["help wanted"]}, {"name": "FIXME", "labels": ["bug"]}]'

--- a/src/TagzApp.Common/Models/Content.cs
+++ b/src/TagzApp.Common/Models/Content.cs
@@ -15,7 +15,10 @@ public class Content
 	/// <summary>
 	///   Id provided by the provider for this content
 	/// </summary>
+	// TODO: CS8618: Non-nullable field is uninitialized. Consider declaring as nullable.
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
 	public string ProviderId { get; set; }
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
 
 	public string HashtagSought { get; set; } = string.Empty;
 


### PR DESCRIPTION
I have found a GitHub Action ([`alstr/todo-to-issue-action`](https://github.com/marketplace/actions/todo-to-issue) ) that finds TODOs, FIXMEs, etc in coding files and creates GitHub Issues.

What `todo-to-issue-action` does:

> This action will convert newly committed TODO comments to GitHub issues on push.
> 
> Optionally, issues can also be closed when the TODOs are removed in a future commit.
> 
> Action supports:
> 
> - Multiple, customizable comments identifiers (FIXME, etc.),
> - Configurable auto-labeling,
> - Assignees,
> - Milestones,
> - Projects (classic).
> - todo-to-issue works with almost any programming language.

This action needs the `Workflow permissions` setting `Read and Write permissions` under `Settings => Actions => General` set in order to be allowed to create issues!

Before (or shortly after the merge) the action needs to be updated to point to the main branch (or whatever condition) in order to look at the main branch for TODOs on pushes.

When the TODO, etc. is removed the Issue is closed automatically. This can be configured. The automatic labeling (`Fix me`, `Help Wanted`, etc.) of issues also can be configured.

As an example on how to use it, I added a TODO in [src/TagzApp.Common/Models/Content.cs](https://github.com/Stelzi79/TagzApp/blob/7917e4fd5fb98a2c5af6bbb16a27619381362d28/src/TagzApp.Common/Models/Content.cs). In my testing in my forked repo this worked. This is the Issue it created for [#2](https://github.com/Stelzi79/TagzApp/issues/2)!

I also added an `.editorconfig` that sets spaces as intentation for `.yml` files in the root directory.

## Next Step:
- add all TODOs, FIXMEs, etc. in changes to the repo