### PR TITLE
Make life easier by committing the cleanup of dotnet.yml separately

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -5,92 +5,91 @@ name: Build and Test .NET projects
 
 on:
   push:
-    branches: [ "main" ]
-    paths: [ "src/**" ]
+    branches: ["main"]
+    paths: ["src/**"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
     types: [opened, synchronize, reopened, closed]
-    paths: [ "src/**" ]
+    paths: ["src/**"]
   workflow_dispatch:
-    branches: [	"main" ]
-
+    branches: ["main"]
 
 jobs:
   build:
-    if: github.event_name == 'workflow_dispatch' || github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')    
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
     runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./src
     steps:
-    - uses: actions/checkout@v3
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: 7.0.x
-    - name: Restore dependencies
-      run: dotnet restore
-    - name: Build
-      run: dotnet build --no-restore
-    - name: Unit Test
-      run: dotnet test --no-build --verbosity normal
-      working-directory: ./src/TagzApp.UnitTest
+      - uses: actions/checkout@v3
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 7.0.x
+      - name: Restore dependencies
+        run: dotnet restore
+      - name: Build
+        run: dotnet build --no-restore
+      - name: Unit Test
+        run: dotnet test --no-build --verbosity normal
+        working-directory: ./src/TagzApp.UnitTest
 
   playwright:
-        if: github.event_name == 'workflow_dispatch' || github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
-        name: 'Playwright Tests'
-        runs-on: ubuntu-latest
-        defaults:
-            run:
-                working-directory: ./src/TagzApp.WebTest
-        timeout-minutes: 10
-        container:
-            image: mcr.microsoft.com/playwright/dotnet:v1.37.1-jammy
-            options: --ipc=host
-        steps:
-            - uses: actions/checkout@v3
-            - name: Setup dotnet
-              uses: actions/setup-dotnet@v3
-              with:
-                dotnet-version: 7.0.x
-            - run: dotnet build
-            - name: Execute Playwright tests
-              env:
-                TestHostStartDelay: 1000
-              run: dotnet test --no-build
-  image:        
-        if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository_owner == 'FritzAndFriends')
-        name: 'Create docker image for Web'
-        runs-on: ubuntu-latest
-        needs: [playwright]
-        steps:
-          - uses: actions/checkout@v3
-          
-          - name: Get current date
-            id: date
-            run: echo "::set-output name=date::$(date +'%Y%m%d')"
-            
-          - name: Docker Login
-            uses: docker/login-action@v2.2.0
-            with:
-              registry: ghcr.io
-              username: ${{ github.actor }}
-              password:  ${{ secrets.GITHUB_TOKEN }}
-              
-          - name: Docker Metadata action
-            id: meta
-            uses: docker/metadata-action@v4.6.0
-            with:
-              images: ghcr.io/${{ github.repository }}
-              tags: |
-               latest
-               ${{ steps.date.outputs.date }}.${{ github.run_attempt }}
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
+    name: "Playwright Tests"
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./src/TagzApp.WebTest
+    timeout-minutes: 10
+    container:
+      image: mcr.microsoft.com/playwright/dotnet:v1.37.1-jammy
+      options: --ipc=host
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup dotnet
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 7.0.x
+      - run: dotnet build
+      - name: Execute Playwright tests
+        env:
+          TestHostStartDelay: 1000
+        run: dotnet test --no-build
+  image:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository_owner == 'FritzAndFriends')
+    name: "Create docker image for Web"
+    runs-on: ubuntu-latest
+    needs: [playwright]
+    steps:
+      - uses: actions/checkout@v3
 
-          - uses: docker/build-push-action@v4.1.1
-            with:
-              context: .
-              file: ./src/TagzApp.Web/dockerfile
-              push: true
-              tags: ${{ steps.meta.outputs.tags }}
-              build-args: |
-                Build_Version: ${{ steps.date.outputs.date }}.${{ github.run_attempt }}
+      - name: Get current date
+        id: date
+        run: echo "::set-output name=date::$(date +'%Y%m%d')"
+
+      - name: Docker Login
+        uses: docker/login-action@v2.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker Metadata action
+        id: meta
+        uses: docker/metadata-action@v4.6.0
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            latest
+            ${{ steps.date.outputs.date }}.${{ github.run_attempt }}
+
+      - uses: docker/build-push-action@v4.1.1
+        with:
+          context: .
+          file: ./src/TagzApp.Web/dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          build-args: |
+            Build_Version: ${{ steps.date.outputs.date }}.${{ github.run_attempt }}


### PR DESCRIPTION
This makes any commits that touch the dotnet.yml easier by committing just the formatting changes to prior!