### PR TITLE
Blazot provider updates

### DIFF
--- a/src/TagzApp.Providers.Blazot/Converters/ContentConverter.cs
+++ b/src/TagzApp.Providers.Blazot/Converters/ContentConverter.cs
@@ -67,7 +67,7 @@ public class ContentConverter : IContentConverter
 					.Combine(BlazotConstants.BaseAppAddress, "transmission", transmission.TransmissionId.ToString())
 					.Replace(@"\", "/")),
 				Text = body,
-				Timestamp = new DateTimeOffset(transmission.DateTransmitted, TimeSpan.Zero).ToLocalTime(),
+				Timestamp = new DateTimeOffset(transmission.DateTransmitted, TimeSpan.Zero),
 				HashtagSought = tag?.Text ?? string.Empty,
 				Type = ContentType.Message
 			};

--- a/src/TagzApp.Providers.Blazot/Formatters/LinkFormatters.cs
+++ b/src/TagzApp.Providers.Blazot/Formatters/LinkFormatters.cs
@@ -14,7 +14,7 @@ internal static class LinkFormatters
     {
       var noHash = m.Value.Trim().TrimStart('#');
       var hashed = m.Value.Trim();
-      return $" <a class=\"b-hashtag-link\" href=\"https://blazot.com/hashtag/{noHash}\">{hashed}</a>";
+      return $" <a class=\"b-hashtag-link\" target=\"_blank\" href=\"https://blazot.com/hashtag/{noHash}\">{hashed}</a>";
     });
   }
 

--- a/src/TagzApp.Providers.Blazot/Formatters/LinkFormatters.cs
+++ b/src/TagzApp.Providers.Blazot/Formatters/LinkFormatters.cs
@@ -5,8 +5,8 @@ namespace TagzApp.Providers.Blazot.Formatters;
 internal static class LinkFormatters
 {
   private static Regex LinkRegex => new(@"(?:(?:https?):\/\/)?[\w/\.-]+(?<!\.)(\.)(?!\.)[a-zA-Z]+(?<!\?)[a-zA-Z0-9/\-&?.=%#_]+(?<!\.)");
-  private static Regex HashTagRegex => new(@"(^|[^&\p{L}\p{M}\p{Nd}_\u200c\u200d\ua67e\u05be\u05f3\u05f4\u309b\u309c\u30a0\u30fb\u3003\u0f0b\u0f0c\u00b7])(#|\uFF03)(?!\uFE0F|\u20E3)([\p{L}\p{M}\p{Nd}_\u200c\u200d\ua67e\u05be\u05f3\u05f4\u309b\u309c\u30a0\u30fb\u3003\u0f0b\u0f0c\u00b7]*[\p{L}\p{M}][\p{L}\p{M}\p{Nd}_\u200c\u200d\ua67e\u05be\u05f3\u05f4\u309b\u309c\u30a0\u30fb\u3003\u0f0b\u0f0c\u00b7]*)");
-  private static Regex UserMentionRegex => new(@"\B@\w+");
+  private static Regex HashTagRegex => new(@"\B#\w\w+");
+	private static Regex UserMentionRegex => new(@"\B@\w+");
 
   public static string AddHashTagLinks(string bodyText)
   {


### PR DESCRIPTION
### Fixed
- Fixed issue with content timestamp preventing transmission from being added to database table.
### Changed
- Added target attribute to text link, so link will open in new window instead of redirecting app.
- Changed Hashtag Regex to a more simplified version that does a better job in situations where the # symbol immediately follows something like ">" (i.e. the hashtag starts a new line and follows `<br/>`).