### PR TITLE
Blazot provider improvements.

### DIFF
--- a/src/TagzApp.Providers.Blazot/BlazotProvider.cs
+++ b/src/TagzApp.Providers.Blazot/BlazotProvider.cs
@@ -4,7 +4,6 @@ using TagzApp.Providers.Blazot.Constants;
 using TagzApp.Providers.Blazot.Interfaces;
 using TagzApp.Providers.Blazot.Models;
 using TagzApp.Providers.Blazot.Configuration;
-using TagzApp.Common.Models;
 
 namespace TagzApp.Providers.Blazot;
 

--- a/src/TagzApp.Providers.Blazot/Converters/ContentConverter.cs
+++ b/src/TagzApp.Providers.Blazot/Converters/ContentConverter.cs
@@ -67,7 +67,7 @@ public class ContentConverter : IContentConverter
 					.Combine(BlazotConstants.BaseAppAddress, "transmission", transmission.TransmissionId.ToString())
 					.Replace(@"\", "/")),
 				Text = body,
-				Timestamp = new DateTimeOffset(transmission.DateTransmitted, TimeSpan.Zero).ToLocalTime(),
+				Timestamp = new DateTimeOffset(transmission.DateTransmitted, TimeSpan.Zero),
 				HashtagSought = tag?.Text ?? string.Empty,
 				Type = ContentType.Message
 			};

--- a/src/TagzApp.Providers.Blazot/TagzApp.Providers.Blazot.csproj
+++ b/src/TagzApp.Providers.Blazot/TagzApp.Providers.Blazot.csproj
@@ -15,6 +15,7 @@
 	  <PackageReference Include="System.Net.Http.Json" Version="7.0.1" />
 	  <ProjectReference Include="..\TagzApp.Common\TagzApp.Common.csproj" />
 	  <ProjectReference Include="..\TagzApp.Communication\TagzApp.Communication.csproj" />
+	  <InternalsVisibleTo Include="TagzApp.UnitTest" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/TagzApp.UnitTest/Blazot/Formatters/LinkFormattersTests.cs
+++ b/src/TagzApp.UnitTest/Blazot/Formatters/LinkFormattersTests.cs
@@ -1,0 +1,17 @@
+﻿using TagzApp.UnitTest.Blazot.TestData;
+
+namespace TagzApp.UnitTest.Blazot.Formatters;
+
+public class LinkFormattersTests
+{
+	[Theory]
+	[ClassData(typeof(HashTagLinkData))]
+	private void AddHashTagLinks_FormatsProperly_Test(string encodedText, string expectedText)
+	{
+		// Act
+		var response = TagzApp.Providers.Blazot.Formatters.LinkFormatters.AddHashTagLinks(encodedText);
+
+		// Assert
+		Assert.Equal(expectedText, response);
+	}
+}

--- a/src/TagzApp.UnitTest/Blazot/TestData/HashTagLinkData.cs
+++ b/src/TagzApp.UnitTest/Blazot/TestData/HashTagLinkData.cs
@@ -1,0 +1,30 @@
+﻿using System.Collections;
+using System.Web;
+
+namespace TagzApp.UnitTest.Blazot.TestData;
+
+public class HashTagLinkData : IEnumerable<object[]>
+{
+	private static readonly string _SimplePunctuationString = "I'm a test message";
+	private static readonly string _HashTagTouching = "I'm a test message <br/>#dotnet";
+	private static readonly string _TypicalString = "I'm a test message #dotnet";
+	private static readonly string _EmoticonString = "I'm a test message 😊 #dotnet";
+
+	private readonly List<object[]> _BodyText = new()
+	{
+		new object[] {HttpUtility.HtmlEncode(_SimplePunctuationString), "I&#39;m a test message"},
+		new object[] {HttpUtility.HtmlEncode(_HashTagTouching), "I&#39;m a test message &lt;br/&gt;<a class=\"b-hashtag-link\" target=\"_blank\" href=\"https://blazot.com/hashtag/dotnet\">#dotnet</a>" },
+		new object[] {HttpUtility.HtmlEncode(_TypicalString), "I&#39;m a test message <a class=\"b-hashtag-link\" target=\"_blank\" href=\"https://blazot.com/hashtag/dotnet\">#dotnet</a>" },
+		new object[] {HttpUtility.HtmlEncode(_EmoticonString), "I&#39;m a test message &#128522; <a class=\"b-hashtag-link\" target=\"_blank\" href=\"https://blazot.com/hashtag/dotnet\">#dotnet</a>" }
+	};
+
+	public IEnumerator<object[]> GetEnumerator()
+	{
+		return _BodyText.GetEnumerator();
+	}
+
+	IEnumerator IEnumerable.GetEnumerator()
+	{
+		return GetEnumerator();
+	}
+}

--- a/src/TagzApp.UnitTest/TagzApp.UnitTest.csproj
+++ b/src/TagzApp.UnitTest/TagzApp.UnitTest.csproj
@@ -25,6 +25,7 @@
   
   <ItemGroup>
     <ProjectReference Include="..\TagzApp.Common\TagzApp.Common.csproj" />
+    <ProjectReference Include="..\TagzApp.Providers.Blazot\TagzApp.Providers.Blazot.csproj" />
     <ProjectReference Include="..\TagzApp.Providers.Mastodon\TagzApp.Providers.Mastodon.csproj" />
     <ProjectReference Include="..\TagzApp.Providers.Youtube\TagzApp.Providers.Youtube.csproj" />
   </ItemGroup>


### PR DESCRIPTION
### Fixed
- Fixed issue with content timestamp preventing transmission from being added to database table.
### Changed
- Added target attribute to text link, so link will open in new window instead of redirecting app.
- Changed Hashtag Regex to a more simplified version that does a better job in situations where the # symbol immediately follows something like ">" (i.e. the hashtag starts a new line and follows `<br/>`).
- Added unit tests to help ensure some HTML Encoded strings aren't mistaken as hashtags.