### PR TITLE
Attempt to fix formatting action

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   build:
     if: github.event_name == 'workflow_dispatch' || github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')    
-    # needs: [code-formatting]
+    needs: [code-formatting]
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -39,7 +39,7 @@ jobs:
 
   playwright:
         if: github.event_name == 'workflow_dispatch' || github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
-        # needs: [code-formatting]
+        needs: [code-formatting]
         name: 'Playwright Tests'
         runs-on: ubuntu-latest
         defaults:
@@ -97,90 +97,103 @@ jobs:
               build-args: |
                 Build_Version: ${{ steps.date.outputs.date }}.${{ github.run_attempt }}
 
-  # code-formatting:
-  #   if: github.event_name == 'workflow_dispatch' || github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
-  #   runs-on: ubuntu-latest
+  code-formatting:
+    # Because the other jobs depend on this one, we need to make sure it runs on the same conditions,
+    # but I only actually want the steps to run on PR open/sync/reopen.
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
+    runs-on: ubuntu-latest
 
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #       with:
-  #         fetch-depth: 0
-  #     - name: Get git diff
-  #       id: diff
-  #       run: |
-  #         git fetch origin main
-  #         {
-  #           echo 'files<<EOF'
-  #           git diff origin/main --name-only --diff-filter=d -- "*.css" "*.js" "*.cs"
-  #           echo EOF
-  #         } >> "$GITHUB_OUTPUT"
+    steps:
+      - name: Setup checkout
+        if: github.event_name == 'pull_request' && github.event.action != 'closed'
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ github.actor }}/TagzApp
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0
+      - name: Get git diff
+        if: github.event_name == 'pull_request' && github.event.action != 'closed'
+        id: diff
+        run: |
+          git remote add upstream https://github.com/FritzAndFriends/TagzApp.git
+          git fetch upstream main
+          {
+            echo 'files<<EOF'
+            git diff upstream/main --name-only --diff-filter=d -- "*.css" "*.js" "*.cs"
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
 
-  #     - name: Get changed C# files
-  #       id: changed_cs
-  #       run: |
-  #         {
-  #           echo 'files<<EOF'
-  #           echo "${{ steps.diff.outputs.files }}" | grep -E "\.cs$" | paste -sd " "
-  #           echo EOF
-  #         } >> "$GITHUB_OUTPUT"
-  #     - name: Add formatting rules to .editorconfig
-  #       if: steps.changed_cs.outputs.files != ''
-  #       run: |
-  #         echo "" >> src/.editorconfig
-  #         echo "[*.cs]" >> src/.editorconfig
-  #         echo "dotnet_diagnostic.IDE0005.severity = error" >> src/.editorconfig # Remove unnecessary using directives
-  #         echo "dotnet_diagnostic.IDE0090.severity = error" >> src/.editorconfig # Simplify new expression
-  #         echo "dotnet_diagnostic.IDE0003.severity = error" >> src/.editorconfig # this and Me preferences
-  #         echo "dotnet_diagnostic.IDE0009.severity = error" >> src/.editorconfig # this and Me preferences
-  #     - name: Setup .NET
-  #       if: steps.changed_cs.outputs.files != ''
-  #       uses: actions/setup-dotnet@v3
-  #       with:
-  #         dotnet-version: 7.0.x
-  #     - name: Run dotnet format
-  #       if: steps.changed_cs.outputs.files != ''
-  #       id: dotnet-format
-  #       run: |
-  #         echo "Running dotnet format on: ${{ steps.changed_cs.outputs.files }}"
-  #         result=$(dotnet format src/TagzApp.sln --verbosity normal --exclude src/TagzApp.Web/Migrations --include ${{ steps.changed_cs.outputs.files }})
-  #         echo "Format result:"
-  #         echo "$result"
-  #         count=$(echo "$result" | grep -c "Formatted code file" || true)
-  #         echo "Number of files Format formatted: $count"
-  #         echo "count=$count" >> "$GITHUB_OUTPUT"
+      - name: Get changed C# files
+        if: github.event_name == 'pull_request' && github.event.action != 'closed'
+        id: changed_cs
+        run: |
+          {
+            echo 'files<<EOF'
+            echo "${{ steps.diff.outputs.files }}" | grep -E "\.cs$" | paste -sd " "
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
+      - name: Add formatting rules to .editorconfig
+        if: (github.event_name == 'pull_request' && github.event.action != 'closed') && steps.changed_cs.outputs.files != ''
+        run: |
+          echo "" >> src/.editorconfig
+          echo "[*.cs]" >> src/.editorconfig
+          echo "dotnet_diagnostic.IDE0005.severity = error" >> src/.editorconfig # Remove unnecessary using directives
+          echo "dotnet_diagnostic.IDE0090.severity = error" >> src/.editorconfig # Simplify new expression
+          echo "dotnet_diagnostic.IDE0003.severity = error" >> src/.editorconfig # this and Me preferences
+          echo "dotnet_diagnostic.IDE0009.severity = error" >> src/.editorconfig # this and Me preferences
+      - name: Setup .NET
+        if: (github.event_name == 'pull_request' && github.event.action != 'closed') && steps.changed_cs.outputs.files != ''
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 7.0.x
+      - name: Run dotnet format
+        if: (github.event_name == 'pull_request' && github.event.action != 'closed') && steps.changed_cs.outputs.files != ''
+        id: dotnet-format
+        run: |
+          echo "Running dotnet format on: ${{ steps.changed_cs.outputs.files }}"
+          result=$(dotnet format src/TagzApp.sln --verbosity normal --exclude src/TagzApp.Web/Migrations --include ${{ steps.changed_cs.outputs.files }})
+          echo "Format result:"
+          echo "$result"
+          count=$(echo "$result" | grep -c "Formatted code file" || true)
+          echo "Number of files Format formatted: $count"
+          echo "count=$count" >> "$GITHUB_OUTPUT"
 
-  #     - name: Get changed JS/CSS files
-  #       id: changed_js_css
-  #       run: |
-  #         {
-  #           echo 'files<<EOF'
-  #           echo "${{ steps.diff.outputs.files }}" | grep -E "\.(js|css)$" | paste -sd " "
-  #           echo EOF
-  #         } >> "$GITHUB_OUTPUT"
-  #     - name: Setup Node
-  #       if: steps.changed_js_css.outputs.files != ''
-  #       uses: actions/setup-node@v3
-  #       with:
-  #         node-version: lts/*
-  #     - name: Run prettier
-  #       if: steps.changed_js_css.outputs.files != ''
-  #       id: prettier
-  #       run: |
-  #         echo "Running prettier on: ${{ steps.changed_js_css.outputs.files }}"
-  #         npm install prettier
-  #         result=$(npx prettier --write --list-different ${{ steps.changed_js_css.outputs.files }})
-  #         echo "Prettier result:"
-  #         echo "$result"
-  #         count=$(echo "$result" | grep -cE "\.(js|css)$" || true)
-  #         echo "Number of files Prettier formatted: $count"
-  #         echo "count=$count" >> "$GITHUB_OUTPUT"
+      - name: Get changed JS/CSS files
+        if: github.event_name == 'pull_request' && github.event.action != 'closed'
+        id: changed_js_css
+        run: |
+          {
+            echo 'files<<EOF'
+            echo "${{ steps.diff.outputs.files }}" | grep -E "\.(js|css)$" | paste -sd " "
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
+      - name: Setup Node
+        if: (github.event_name == 'pull_request' && github.event.action != 'closed') && steps.changed_js_css.outputs.files != ''
+        uses: actions/setup-node@v3
+        with:
+          node-version: lts/*
+      - name: Run prettier
+        if: (github.event_name == 'pull_request' && github.event.action != 'closed') && steps.changed_js_css.outputs.files != ''
+        id: prettier
+        run: |
+          echo "Running prettier on: ${{ steps.changed_js_css.outputs.files }}"
+          npm install prettier
+          result=$(npx prettier --write --list-different ${{ steps.changed_js_css.outputs.files }})
+          echo "Prettier result:"
+          echo "$result"
+          count=$(echo "$result" | grep -cE "\.(js|css)$" || true)
+          echo "Number of files Prettier formatted: $count"
+          echo "count=$count" >> "$GITHUB_OUTPUT"
 
-  #     - name: Commit if changes
-  #       if: steps.prettier.outputs.count > 0 || steps.dotnet-format.outputs.count > 0
-  #       run: |
-  #         git config user.name "github-actions"
-  #         git config user.email "github-actions@github.com"
-  #         git add *.cs *.js *.css
-  #         echo "$(git status)"
-  #         git commit -m "Applying formatting changes through GitHub Actions"
-  #         git push origin HEAD:${{ github.head_ref }}
+      - name: Commit if changes
+        if: (github.event_name == 'pull_request' && github.event.action != 'closed') && steps.prettier.outputs.count > 0 || steps.dotnet-format.outputs.count > 0
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git add *.cs *.js *.css
+          echo "$(git status)"
+          git commit -m "Applying formatting changes through GitHub Actions"
+          git push

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -99,7 +99,7 @@ jobs:
 
   code-formatting:
     # Because the other jobs depend on this one, we need to make sure it runs on the same conditions,
-    # but I only actually want the steps to run on PR open/sync/reopen.
+    # but we only actually want the steps to run on PR open/sync/reopen.
     if: github.event_name == 'workflow_dispatch' || github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
     runs-on: ubuntu-latest
 
@@ -187,7 +187,7 @@ jobs:
 
       - name: Commit if changes
         if: (github.event_name == 'pull_request' && github.event.action != 'closed') && steps.prettier.outputs.count > 0 || steps.dotnet-format.outputs.count > 0
-        continue-on-error: true
+        continue-on-error: true # fail-safe to make sure the build and tests run.
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/src/TagzApp.Web/Pages/Error.cshtml.cs
+++ b/src/TagzApp.Web/Pages/Error.cshtml.cs
@@ -12,11 +12,11 @@ namespace TagzApp.Web.Pages
 
 		public bool ShowRequestId => !string.IsNullOrEmpty(RequestId);
 
-		private readonly ILogger<ErrorModel> _logger;
+		private readonly ILogger<ErrorModel> _Logger;
 
 		public ErrorModel(ILogger<ErrorModel> logger)
 		{
-			_logger = logger;
+			_Logger = logger;
 		}
 
 		public void OnGet()


### PR DESCRIPTION
Unfortunately even with my change to `commit` step, it still doesn't have permissions. With `continue-on-error: true` the other jobs in the workflow are not blocked by `code-formatting` failing.

In order to trigger formatting/commit I corrected a Naming Rule violation in `src/TagzApp.Web/Pages/Error.cshtml.cs`: `_logger;` → `_Logger;`

`commit` step error:

```bash
On branch fix_Formatting
Your branch is up to date with 'origin/fix_Formatting'.

Changes to be committed:
  (use "git restore --staged <file>..." to unstage)
	modified:   src/TagzApp.Web/Pages/Error.cshtml.cs

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	modified:   src/.editorconfig
[fix_Formatting 7a3476a] Applying formatting changes through GitHub Actions
 1 file changed, 27 insertions(+), 27 deletions(-)
remote: Permission to degenone/TagzApp.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/degenone/TagzApp/': The requested URL returned error: 403
Error: Process completed with exit code 128.
```

**Do we want to keep the job commented out or make this change?** It would add a bit of time to the workflows. With just one file in this PR, `Run dotnet format` step took 48 seconds.