### PR TITLE
Changed formatting-action diff to compare to merge-base instead of upstream/main.

### DIFF
--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -15,14 +15,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: Get git diff
         id: diff
         run: |
-          git remote add upstream https://github.com/FritzAndFriends/TagzApp.git
-          git fetch upstream main
           {
             echo 'files<<EOF'
-            git diff upstream/main --name-only --diff-filter=d -- "*.css" "*.js" "*.cs"
+            git diff origin/main...HEAD --name-only --diff-filter=d -- "*.css" "*.js" "*.cs"
             echo EOF
           } >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
I noticed that the action could find "false positive" changes when files were updated on `upstream/main` that were not synced to the pushed branch. 