### PR TITLE
Suggestion: Minor Moderation UI change

### DIFF
--- a/src/TagzApp.Web/wwwroot/css/site.css
+++ b/src/TagzApp.Web/wwwroot/css/site.css
@@ -318,8 +318,7 @@ span.invisible {
 	flex-direction: row;
 	justify-content: center;
 	align-items: center;
-	background-color: #ccc;
-	opacity: 0.7;
+	background-color: rgba(204, 204, 204, 0.7);
 	z-index: 10;
 }
 


### PR DESCRIPTION
I removed the `opacity` property from `#moderationAction` and added it to the `background-color` property.  This makes the moderation action buttons solid color. This might come down to taste, so feel free to reject this if we want to keep the opacity on the buttons.

## UI Before change

![ui_before](https://github.com/FritzAndFriends/TagzApp/assets/48437506/889a2cf1-312b-4534-99bc-d414ae9707d4)

## UI After change

![ui_after](https://github.com/FritzAndFriends/TagzApp/assets/48437506/2b53bc7d-6573-40ee-9e78-f90546db5b7a)
