### PR TITLE
Fix YouTubeChatProvider Error

### DIFF
--- a/src/TagzApp.Providers.YouTubeChat/YouTubeChatProvider.cs
+++ b/src/TagzApp.Providers.YouTubeChat/YouTubeChatProvider.cs
@@ -165,7 +165,7 @@ public class YouTubeChatProvider : ISocialMediaProvider, IDisposable
 		catch (Google.GoogleApiException ex)
 		{
 			// GoogleApiException: The service youtube has thrown an exception. HttpStatusCode is Forbidden. The user is not enabled for live streaming.
-			Console.WriteLine($"Exception while fetching YouTube broadcasts: {ex.Message}");			
+			Console.WriteLine($"Exception while fetching YouTube broadcasts: {ex.Message}");
 			return Enumerable.Empty<YouTubeBroadcast>();
 		}
 

--- a/src/TagzApp.Providers.YouTubeChat/YouTubeChatProvider.cs
+++ b/src/TagzApp.Providers.YouTubeChat/YouTubeChatProvider.cs
@@ -144,7 +144,8 @@ public class YouTubeChatProvider : ISocialMediaProvider, IDisposable
 		channelRequest.Mine = true;
 		var channels = channelRequest.Execute();
 
-		return channels.Items.First().Snippet.Title;
+		// Not sure if this is needed, can't replicate "fisrt" error. (https://github.com/FritzAndFriends/TagzApp/issues/241)
+		return channels.Items?.First().Snippet.Title ?? "Unknown Channel Title";
 
 	}
 
@@ -156,7 +157,17 @@ public class YouTubeChatProvider : ISocialMediaProvider, IDisposable
 		var listRequest = service.LiveBroadcasts.List("snippet");
 		listRequest.Mine = true;
 		listRequest.BroadcastType = LiveBroadcastsResource.ListRequest.BroadcastTypeEnum.Event__;
-		var broadcasts = listRequest.Execute();
+		LiveBroadcastListResponse broadcasts;
+		try
+		{
+			broadcasts = listRequest.Execute();
+		}
+		catch (Google.GoogleApiException ex)
+		{
+			// GoogleApiException: The service youtube has thrown an exception. HttpStatusCode is Forbidden. The user is not enabled for live streaming.
+			Console.WriteLine($"Exception while fetching YouTube broadcasts: {ex.Message}");			
+			return Enumerable.Empty<YouTubeBroadcast>();
+		}
 
 		var outBroadcasts = new List<YouTubeBroadcast>();
 		outBroadcasts.AddRange(broadcasts.Items

--- a/src/TagzApp.Web/Areas/Admin/Pages/YouTubeChat.cshtml
+++ b/src/TagzApp.Web/Areas/Admin/Pages/YouTubeChat.cshtml
@@ -11,6 +11,10 @@
 {
 	<p><a href="~/Identity/Account/Manage/ExternalLogins">Login with a Google Id</a> to start connecting TagzApp to YouTube</p>
 }
+else if (Model.Broadcasts.Count() == 0)
+{
+	<p>There are no live events for channel: '@Model.ChannelTitle'. <strong>Consider checking the correct account is registered.</strong></p>
+}
 else
 {
 


### PR DESCRIPTION
Oddly I was not able to recreate the case where `channels.Items` was `null`, but I left the fix in.