### PR TITLE
feat: Add DisableContextMenu function

### DIFF
--- a/src/TagzApp.Web/wwwroot/js/site.js
+++ b/src/TagzApp.Web/wwwroot/js/site.js
@@ -73,6 +73,7 @@
 		try {
 			await connection.start();
 			console.log('SignalR Connected.');
+			DisableContextMenu();
 		} catch (err) {
 			console.log(err);
 			setTimeout(start, 5000);
@@ -81,6 +82,10 @@
 		connection.onclose(async () => {
 			await start();
 		});
+	}
+
+	function DisableContextMenu() {
+		document.addEventListener('contextmenu', ev => ev.preventDefault());
 	}
 
 	function RemoveActivePanel() {

--- a/src/TagzApp.Web/wwwroot/js/site.js
+++ b/src/TagzApp.Web/wwwroot/js/site.js
@@ -1,4 +1,4 @@
-﻿(function () {
+(function () {
 	var connection;
 
 	const ModerationState = {
@@ -73,7 +73,6 @@
 		try {
 			await connection.start();
 			console.log('SignalR Connected.');
-			DisableContextMenu();
 		} catch (err) {
 			console.log(err);
 			setTimeout(start, 5000);
@@ -82,10 +81,6 @@
 		connection.onclose(async () => {
 			await start();
 		});
-	}
-
-	function DisableContextMenu() {
-		document.addEventListener('contextmenu', ev => ev.preventDefault());
 	}
 
 	function RemoveActivePanel() {
@@ -604,6 +599,10 @@
 		});
 	}
 
+	function DisableContextMenu() {
+		document.addEventListener('contextmenu', ev => ev.preventDefault());
+	}
+
 	function FormatPauseButton() {
 		if (paused) {
 			pauseButton.classList.remove('bi-pause-circle-fill');
@@ -1021,6 +1020,8 @@
 					});
 					window.Masonry.resizeAllGridItems();
 				});
+
+			DisableContextMenu();
 		},
 
 		ListenForModerationContent: async function (tag) {


### PR DESCRIPTION
This commit adds a new function called DisableContextMenu to the site.js file. This function prevents the context menu from appearing when right-clicking on the page.

Resolves #299 