### PR TITLE
Forcing Waterfall to pause state when modal opened

### DIFF
--- a/src/TagzApp.Blazor.Client/Components/Pages/Waterfall.razor
+++ b/src/TagzApp.Blazor.Client/Components/Pages/Waterfall.razor
@@ -122,6 +122,7 @@ else
 	async Task ShowModal(ContentModel content)
 	{
 
+		thePauseButton.SetPauseState(true);
 		ModalContent = content;
 		await _Connection.InvokeAsync("SendMessageToOverlay", TagTracked, content.Provider, content.ProviderId);
 		await Modal.Open();


### PR DESCRIPTION
Fixes #387 

Purposefully NOT resuming after modal is closed in case there is a backlog of messages