### PR TITLE
Fixed a bug with `GetFilteredContentByTag`

### DIFF
--- a/src/TagzApp.Blazor.Client/Components/Pages/Moderation.razor
+++ b/src/TagzApp.Blazor.Client/Components/Pages/Moderation.razor
@@ -334,7 +334,7 @@
 	{
 
 		var approvalStatus = (int)_FilterApprovalStatus;
-		var currentContent = (await _Connection.InvokeAsync<IEnumerable<ModerationContentModel>>("GetFilteredContentByTag", _Tag, _FilteredProviders.ToArray(), approvalStatus.ToString()))
+		var currentContent = (await _Connection.InvokeAsync<IEnumerable<ModerationContentModel>>("GetFilteredContentByTag", _Tag, _FilteredProviders.ToArray(), approvalStatus))
 			.ToArray();
 
 		foreach (var content in currentContent.OrderByDescending(c => c.Timestamp).ToArray())

--- a/src/TagzApp.Blazor/Hubs/ModerationHub.cs
+++ b/src/TagzApp.Blazor/Hubs/ModerationHub.cs
@@ -111,12 +111,12 @@ public class ModerationHub : Hub<IModerationClient>
 
 	}
 
-	public async Task<IEnumerable<ModerationContentModel>> GetFilteredContentByTag(string tag, string[] providers, string state)
+	public async Task<IEnumerable<ModerationContentModel>> GetFilteredContentByTag(string tag, string[] providers, int state)
 	{
 
-		var states = string.IsNullOrEmpty(state) || state == "-1" ?
+		var states = state == -1 ?
 			[ModerationState.Pending, ModerationState.Approved, ModerationState.Rejected] :
-			new[] { Enum.Parse<ModerationState>(state) };
+			new[] { (ModerationState)state };
 
 		var results = (await _Service.GetFilteredContentByTag(tag, providers, states))
 			.Select(c => ModerationContentModel.ToModerationContentModel(c.Item1, c.Item2))


### PR DESCRIPTION
When navigationg to `/Moderation` I got an error:
```
crit: Microsoft.AspNetCore.Components.WebAssembly.Rendering.WebAssemblyRenderer[100]
      Unhandled exception rendering component: An unexpected error occurred invoking 'GetFilteredContentByTag' on the server.
Microsoft.AspNetCore.SignalR.HubException: An unexpected error occurred invoking 'GetFilteredContentByTag' on the server.
   at Microsoft.AspNetCore.SignalR.Client.HubConnection.InvokeCoreAsyncCore(String methodName, Type returnType, Object[] args, CancellationToken cancellationToken)
   at Microsoft.AspNetCore.SignalR.Client.HubConnection.InvokeCoreAsync(String methodName, Type returnType, Object[] args, CancellationToken cancellationToken)
   at Microsoft.AspNetCore.SignalR.Client.HubConnectionExtensions.<InvokeCoreAsync>d__43`1[[System.Collections.Generic.IEnumerable`1[[TagzApp.ViewModels.Data.ModerationContentModel, TagzApp.ViewModels, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]], System.Private.CoreLib, Version=8.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]].MoveNext()
   at TagzApp.Blazor.Client.Components.Pages.Moderation.InitializeContent() in C:\Users\terpp\dev\TagzApp\src\TagzApp.Blazor.Client\Components\Pages\Moderation.razor:line 337
   at TagzApp.Blazor.Client.Components.Pages.Moderation.OnInitializedAsync() in C:\Users\terpp\dev\TagzApp\src\TagzApp.Blazor.Client\Components\Pages\Moderation.razor:line 171
   at Microsoft.AspNetCore.Components.ComponentBase.RunInitAndSetParametersAsync()
   at Microsoft.AspNetCore.Components.RenderTree.Renderer.GetErrorHandledTask(Task taskToHandle, ComponentState owningComponentState)
```

Adding the following code to [ModerationHub.GetFilteredContentByTag](https://github.com/FritzAndFriends/TagzApp/blob/main/src/TagzApp.Blazor/Hubs/ModerationHub.cs#L114)
```csharp
string negOne = "-1";
Console.WriteLine($"state({state}) == negOne({negOne}) ? {state == negOne} | signs: state({(int)state[0]}) negOne({(int)negOne[0]})");
```
It prints `state(−1) == negOne(-1) ? False | signs: state(8722) negOne(45)`.

I felt that the simplest change was to have `state` be an `int` instead of `string` and this fixed the bug.
