### PR TITLE
Fix to formatting action

### DIFF
--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -48,6 +48,9 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 8.0.x
+      - name: Workload install
+        if: steps.changed_cs.outputs.files != ''
+        run: dotnet workload restore src/TagzApp.sln
       - name: Run dotnet format
         if: steps.changed_cs.outputs.files != ''
         id: dotnet-format


### PR DESCRIPTION
`dotnet format` needed workload installation step for some reason.

The action should work now, at least based on tests on my repo it does. 😅