### PR TITLE
Fix moderation sync across moderator screens

### DIFF
--- a/src/TagzApp.Blazor.Client/Components/Pages/Moderation.razor
+++ b/src/TagzApp.Blazor.Client/Components/Pages/Moderation.razor
@@ -139,7 +139,9 @@
 
 	private HashSet<dynamic> _PauseQueue = new();
 
-	private static string GetContentKey(ModerationContentModel content) => $"{content.Provider}:{content.ProviderId}";
+	private static string GetContentKey(ModerationContentModel content) => ModerationContentFilter.GetContentKey(content);
+
+	private int CurrentFilterState => (int)_FilterApprovalStatus;
 
 	private IEnumerable<ModerationContentModel> GetContentInChronologicalOrder() => 
 		_Content.Values.OrderByDescending(c => c.Timestamp);
@@ -425,7 +427,7 @@ private static readonly TimeSpan _ConnectionTimeout = TimeSpan.FromSeconds(3); /
 		{
 
 			if (!_FilteredProviders.Any(c => c.Equals(content.Provider, StringComparison.InvariantCultureIgnoreCase))) return;
-			if (_FilterApprovalStatus != FilterModerationState.All && _FilterApprovalStatus != FilterModerationState.Pending) return;
+			if (!ModerationContentFilter.ShouldDisplay(CurrentFilterState, ModerationState.Pending)) return;
 
 			if (ThePauseButton.IsPaused)
 			{
@@ -463,17 +465,7 @@ private static readonly TimeSpan _ConnectionTimeout = TimeSpan.FromSeconds(3); /
 				return;
 			}
 
-			var contentKey = GetContentKey(content);
-			if (_Content.TryGetValue(contentKey, out var existing))
-			{
-				if (existing.State == ModerationState.Rejected) return;
-				existing.State = ModerationState.Rejected;
-				existing.ModerationTimestamp = content.ModerationTimestamp;
-			}
-			else
-			{
-				_Content[contentKey] = content;
-			}
+			ModerationContentFilter.ApplyModerationUpdate(_Content, content, CurrentFilterState);
 
 			await InvokeAsync(StateHasChanged);
 
@@ -521,17 +513,7 @@ private static readonly TimeSpan _ConnectionTimeout = TimeSpan.FromSeconds(3); /
 			return;
 		}
 
-		var contentKey = GetContentKey(content);
-		if (_Content.TryGetValue(contentKey, out var existing))
-		{
-			if (existing.State == ModerationState.Approved) return;
-			existing.State = ModerationState.Approved;
-			existing.ModerationTimestamp = content.ModerationTimestamp;
-		}
-		else
-		{
-			_Content[contentKey] = content;
-		}
+		ModerationContentFilter.ApplyModerationUpdate(_Content, content, CurrentFilterState);
 		await InvokeAsync(StateHasChanged);
 
 	}
@@ -576,8 +558,13 @@ private static readonly TimeSpan _ConnectionTimeout = TimeSpan.FromSeconds(3); /
 			{
 				if (item is ContentModel content)
 				{
+					if (!ModerationContentFilter.ShouldDisplay(CurrentFilterState, ModerationState.Pending)) continue;
 					var moderationContent = ModerationContentModel.ToModerationContentModel(content);
 					_Content[GetContentKey(moderationContent)] = moderationContent;
+				}
+				else if (item is ModerationContentModel moderationContent)
+				{
+					ModerationContentFilter.ApplyModerationUpdate(_Content, moderationContent, CurrentFilterState);
 				}
 			}
 			_PauseQueue.Clear();

--- a/src/TagzApp.UnitTest/TagzApp.UnitTest.csproj
+++ b/src/TagzApp.UnitTest/TagzApp.UnitTest.csproj
@@ -34,6 +34,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\TagzApp.Common\TagzApp.Common.csproj" />
+    <ProjectReference Include="..\TagzApp.ViewModels\TagzApp.ViewModels.csproj" />
     <ProjectReference Include="..\TagzApp.Configuration.AzureKeyVault\TagzApp.Configuration.AzureKeyVault.csproj" />
     <ProjectReference Include="..\TagzApp.Providers.Blazot\TagzApp.Providers.Blazot.csproj" />
     <ProjectReference Include="..\TagzApp.Providers.Mastodon\TagzApp.Providers.Mastodon.csproj" />

--- a/src/TagzApp.UnitTest/ViewModels/ModerationContentFilterTests.cs
+++ b/src/TagzApp.UnitTest/ViewModels/ModerationContentFilterTests.cs
@@ -1,0 +1,80 @@
+using TagzApp.ViewModels.Data;
+
+namespace TagzApp.UnitTest.ViewModels;
+
+public class ModerationContentFilterTests
+{
+	[Fact]
+	public void ApplyModerationUpdate_RemovesApprovedContentFromPendingView()
+	{
+		var existing = CreateContent(ModerationState.Pending, providerId: "one");
+		var content = new Dictionary<string, ModerationContentModel>
+		{
+			[ModerationContentFilter.GetContentKey(existing)] = existing
+		};
+		var approved = CreateContent(
+			ModerationState.Approved,
+			providerId: "one",
+			reason: "Reviewed",
+			moderator: "MODERATOR");
+
+		ModerationContentFilter.ApplyModerationUpdate(content, approved, filterState: (int)ModerationState.Pending);
+
+		Assert.Empty(content);
+	}
+
+	[Fact]
+	public void ApplyModerationUpdate_ReplacesExistingContentWhenFilterMatches()
+	{
+		var existing = CreateContent(ModerationState.Pending, providerId: "one");
+		var content = new Dictionary<string, ModerationContentModel>
+		{
+			[ModerationContentFilter.GetContentKey(existing)] = existing
+		};
+		var approved = CreateContent(
+			ModerationState.Approved,
+			providerId: "one",
+			reason: "Reviewed",
+			moderator: "MODERATOR");
+
+		ModerationContentFilter.ApplyModerationUpdate(content, approved, filterState: ModerationContentFilter.AllStates);
+
+		var stored = Assert.Single(content).Value;
+		Assert.Same(approved, stored);
+		Assert.Equal(ModerationState.Approved, stored.State);
+		Assert.Equal("Reviewed", stored.Reason);
+		Assert.Equal("MODERATOR", stored.Moderator);
+	}
+
+	[Fact]
+	public void ShouldDisplay_ReturnsExpectedValuesForModerationFilters()
+	{
+		Assert.True(ModerationContentFilter.ShouldDisplay(ModerationContentFilter.AllStates, ModerationState.Pending));
+		Assert.True(ModerationContentFilter.ShouldDisplay((int)ModerationState.Approved, ModerationState.Approved));
+		Assert.False(ModerationContentFilter.ShouldDisplay((int)ModerationState.Approved, ModerationState.Rejected));
+		Assert.False(ModerationContentFilter.ShouldDisplay((int)ModerationState.Pending, ModerationState.Approved));
+	}
+
+	private static ModerationContentModel CreateContent(
+		ModerationState state,
+		string providerId,
+		string? reason = null,
+		string? moderator = null) =>
+		new(
+			Provider: "TEST",
+			ProviderId: providerId,
+			Type: "Post",
+			SourceUri: "https://example.com/post/" + providerId,
+			Timestamp: DateTimeOffset.UtcNow,
+			AuthorDisplayName: "Author",
+			AuthorUserName: "@author",
+			AuthorProfileUri: "https://example.com/author",
+			AuthorProfileImageUri: "https://example.com/author.png",
+			Text: "Hello world",
+			PreviewCard: null,
+			State: state,
+			Reason: reason,
+			Moderator: moderator,
+			ModerationTimestamp: DateTimeOffset.UtcNow,
+			Emotes: []);
+}

--- a/src/TagzApp.ViewModels/Data/ModerationContentFilter.cs
+++ b/src/TagzApp.ViewModels/Data/ModerationContentFilter.cs
@@ -1,0 +1,28 @@
+namespace TagzApp.ViewModels.Data;
+
+public static class ModerationContentFilter
+{
+	public const int AllStates = -1;
+
+	public static string GetContentKey(string provider, string providerId) => $"{provider}:{providerId}";
+
+	public static string GetContentKey(ModerationContentModel content) => GetContentKey(content.Provider, content.ProviderId);
+
+	public static bool ShouldDisplay(int filterState, ModerationState contentState) =>
+		filterState == AllStates || filterState == (int)contentState;
+
+	public static void ApplyModerationUpdate(
+		IDictionary<string, ModerationContentModel> content,
+		ModerationContentModel updatedContent,
+		int filterState)
+	{
+		var contentKey = GetContentKey(updatedContent);
+		if (!ShouldDisplay(filterState, updatedContent.State))
+		{
+			content.Remove(contentKey);
+			return;
+		}
+
+		content[contentKey] = updatedContent;
+	}
+}


### PR DESCRIPTION
## Summary
- make moderation SignalR updates respect the active filter on the moderation page
- remove items from Needs Review when another moderator approves or rejects them
- add unit tests for the shared moderation content filter helper

## Testing
- dotnet build TagzApp.Blazor --no-restore
- dotnet test src/TagzApp.UnitTest --no-restore --verbosity normal

Fixes #550