### PR TITLE
Configure all-contributors for README contributors panel

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,0 +1,206 @@
+{
+  "files": [
+    "README.md"
+  ],
+  "imageSize": 100,
+  "commit": false,
+  "commitType": "docs",
+  "commitConvention": "angular",
+  "contributors": [
+    {
+      "login": "csharpfritz",
+      "name": "Jeffrey T. Fritz",
+      "avatar_url": "https://github.com/csharpfritz.png",
+      "profile": "https://github.com/csharpfritz",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "degenone",
+      "name": "Tero Kilpelainen",
+      "avatar_url": "https://github.com/degenone.png",
+      "profile": "https://github.com/degenone",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "Stelzi79",
+      "name": "Stelzi79",
+      "avatar_url": "https://github.com/Stelzi79.png",
+      "profile": "https://github.com/Stelzi79",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "NapalmCodes",
+      "name": "Shawn Vause",
+      "avatar_url": "https://github.com/NapalmCodes.png",
+      "profile": "https://github.com/NapalmCodes",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "CZEMacLeod",
+      "name": "Cynthia MacLeod",
+      "avatar_url": "https://github.com/CZEMacLeod.png",
+      "profile": "https://github.com/CZEMacLeod",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "ElliottBrand",
+      "name": "Steve Elliott",
+      "avatar_url": "https://github.com/ElliottBrand.png",
+      "profile": "https://github.com/ElliottBrand",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "JBraunsmaJr",
+      "name": "Badger",
+      "avatar_url": "https://github.com/JBraunsmaJr.png",
+      "profile": "https://github.com/JBraunsmaJr",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "eric-vanartsdalen",
+      "name": "Eric VanArtsdalen",
+      "avatar_url": "https://github.com/eric-vanartsdalen.png",
+      "profile": "https://github.com/eric-vanartsdalen",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "paddybhoy66",
+      "name": "Pat Woods",
+      "avatar_url": "https://github.com/paddybhoy66.png",
+      "profile": "https://github.com/paddybhoy66",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "SQL-MisterMagoo",
+      "name": "SQL-MisterMagoo",
+      "avatar_url": "https://github.com/SQL-MisterMagoo.png",
+      "profile": "https://github.com/SQL-MisterMagoo",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "mpaulosky",
+      "name": "mpaulosky",
+      "avatar_url": "https://github.com/mpaulosky.png",
+      "profile": "https://github.com/mpaulosky",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "mcNets",
+      "name": "Joan Magnet",
+      "avatar_url": "https://github.com/mcNets.png",
+      "profile": "https://github.com/mcNets",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "johanbenschop",
+      "name": "Johan Benschop",
+      "avatar_url": "https://github.com/johanbenschop.png",
+      "profile": "https://github.com/johanbenschop",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "jedelfraisse",
+      "name": "Jonathan Delfraisse",
+      "avatar_url": "https://github.com/jedelfraisse.png",
+      "profile": "https://github.com/jedelfraisse",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "justinhhorner",
+      "name": "Justin Horner",
+      "avatar_url": "https://github.com/justinhhorner.png",
+      "profile": "https://github.com/justinhhorner",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "NickSpaghetti",
+      "name": "Nick Spaghetti",
+      "avatar_url": "https://github.com/NickSpaghetti.png",
+      "profile": "https://github.com/NickSpaghetti",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "mogas",
+      "name": "Nuno Silva",
+      "avatar_url": "https://github.com/mogas.png",
+      "profile": "https://github.com/mogas",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "szalapski",
+      "name": "Patrick Szalapski",
+      "avatar_url": "https://github.com/szalapski.png",
+      "profile": "https://github.com/szalapski",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "acidrod",
+      "name": "Rodrigo Alarcon",
+      "avatar_url": "https://github.com/acidrod.png",
+      "profile": "https://github.com/acidrod",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "ryanshaut",
+      "name": "Ryan Shaut",
+      "avatar_url": "https://github.com/ryanshaut.png",
+      "profile": "https://github.com/ryanshaut",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "ThindalTV",
+      "name": "Thindal",
+      "avatar_url": "https://github.com/ThindalTV.png",
+      "profile": "https://github.com/ThindalTV",
+      "contributions": [
+        "code"
+      ]
+    }
+  ],
+  "contributorsPerLine": 7,
+  "skipCi": true,
+  "repoType": "github",
+  "repoHost": "https://github.com",
+  "projectName": "TagzApp",
+  "projectOwner": "FritzAndFriends"
+}

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A website tool that searches social media for hashtags, and tracks chat interaction on several live streaming services
 
+<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+[![All Contributors](https://img.shields.io/badge/all_contributors-21-orange.svg?style=flat-square)](#contributors-)
+<!-- ALL-CONTRIBUTORS-BADGE:END -->
+
 ![Screenshot from .NET Conf 2024](doc/img/dotnetconf2024-inuse.png)
 
 ### Overlay display
@@ -80,3 +84,45 @@ Built on modern .NET technologies for scalability and performance:
 ## Contributing or running in development mode
 
 If you want to run your own version of TagzApp locally, check out the [CONTRIBUTING.md](CONTRIBUTING.md) document
+
+## Contributors ✨
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+<table>
+  <tbody>
+    <tr>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/csharpfritz"><img src="https://github.com/csharpfritz.png?size=100" width="100px;" alt="Jeffrey T. Fritz"/><br /><sub><b>Jeffrey T. Fritz</b></sub></a><br /><a href="https://github.com/FritzAndFriends/TagzApp/commits?author=csharpfritz" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/degenone"><img src="https://github.com/degenone.png?size=100" width="100px;" alt="Tero Kilpelainen"/><br /><sub><b>Tero Kilpelainen</b></sub></a><br /><a href="https://github.com/FritzAndFriends/TagzApp/commits?author=degenone" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/Stelzi79"><img src="https://github.com/Stelzi79.png?size=100" width="100px;" alt="Stelzi79"/><br /><sub><b>Stelzi79</b></sub></a><br /><a href="https://github.com/FritzAndFriends/TagzApp/commits?author=Stelzi79" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/NapalmCodes"><img src="https://github.com/NapalmCodes.png?size=100" width="100px;" alt="Shawn Vause"/><br /><sub><b>Shawn Vause</b></sub></a><br /><a href="https://github.com/FritzAndFriends/TagzApp/commits?author=NapalmCodes" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/CZEMacLeod"><img src="https://github.com/CZEMacLeod.png?size=100" width="100px;" alt="Cynthia MacLeod"/><br /><sub><b>Cynthia MacLeod</b></sub></a><br /><a href="https://github.com/FritzAndFriends/TagzApp/commits?author=CZEMacLeod" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/ElliottBrand"><img src="https://github.com/ElliottBrand.png?size=100" width="100px;" alt="Steve Elliott"/><br /><sub><b>Steve Elliott</b></sub></a><br /><a href="https://github.com/FritzAndFriends/TagzApp/commits?author=ElliottBrand" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/JBraunsmaJr"><img src="https://github.com/JBraunsmaJr.png?size=100" width="100px;" alt="Badger"/><br /><sub><b>Badger</b></sub></a><br /><a href="https://github.com/FritzAndFriends/TagzApp/commits?author=JBraunsmaJr" title="Code">💻</a></td>
+    </tr>
+    <tr>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/eric-vanartsdalen"><img src="https://github.com/eric-vanartsdalen.png?size=100" width="100px;" alt="Eric VanArtsdalen"/><br /><sub><b>Eric VanArtsdalen</b></sub></a><br /><a href="https://github.com/FritzAndFriends/TagzApp/commits?author=eric-vanartsdalen" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/paddybhoy66"><img src="https://github.com/paddybhoy66.png?size=100" width="100px;" alt="Pat Woods"/><br /><sub><b>Pat Woods</b></sub></a><br /><a href="https://github.com/FritzAndFriends/TagzApp/commits?author=paddybhoy66" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/SQL-MisterMagoo"><img src="https://github.com/SQL-MisterMagoo.png?size=100" width="100px;" alt="SQL-MisterMagoo"/><br /><sub><b>SQL-MisterMagoo</b></sub></a><br /><a href="https://github.com/FritzAndFriends/TagzApp/commits?author=SQL-MisterMagoo" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/mpaulosky"><img src="https://github.com/mpaulosky.png?size=100" width="100px;" alt="mpaulosky"/><br /><sub><b>mpaulosky</b></sub></a><br /><a href="https://github.com/FritzAndFriends/TagzApp/commits?author=mpaulosky" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/mcNets"><img src="https://github.com/mcNets.png?size=100" width="100px;" alt="Joan Magnet"/><br /><sub><b>Joan Magnet</b></sub></a><br /><a href="https://github.com/FritzAndFriends/TagzApp/commits?author=mcNets" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/johanbenschop"><img src="https://github.com/johanbenschop.png?size=100" width="100px;" alt="Johan Benschop"/><br /><sub><b>Johan Benschop</b></sub></a><br /><a href="https://github.com/FritzAndFriends/TagzApp/commits?author=johanbenschop" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/jedelfraisse"><img src="https://github.com/jedelfraisse.png?size=100" width="100px;" alt="Jonathan Delfraisse"/><br /><sub><b>Jonathan Delfraisse</b></sub></a><br /><a href="https://github.com/FritzAndFriends/TagzApp/commits?author=jedelfraisse" title="Code">💻</a></td>
+    </tr>
+    <tr>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/justinhhorner"><img src="https://github.com/justinhhorner.png?size=100" width="100px;" alt="Justin Horner"/><br /><sub><b>Justin Horner</b></sub></a><br /><a href="https://github.com/FritzAndFriends/TagzApp/commits?author=justinhhorner" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/NickSpaghetti"><img src="https://github.com/NickSpaghetti.png?size=100" width="100px;" alt="Nick Spaghetti"/><br /><sub><b>Nick Spaghetti</b></sub></a><br /><a href="https://github.com/FritzAndFriends/TagzApp/commits?author=NickSpaghetti" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/mogas"><img src="https://github.com/mogas.png?size=100" width="100px;" alt="Nuno Silva"/><br /><sub><b>Nuno Silva</b></sub></a><br /><a href="https://github.com/FritzAndFriends/TagzApp/commits?author=mogas" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/szalapski"><img src="https://github.com/szalapski.png?size=100" width="100px;" alt="Patrick Szalapski"/><br /><sub><b>Patrick Szalapski</b></sub></a><br /><a href="https://github.com/FritzAndFriends/TagzApp/commits?author=szalapski" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/acidrod"><img src="https://github.com/acidrod.png?size=100" width="100px;" alt="Rodrigo Alarcon"/><br /><sub><b>Rodrigo Alarcon</b></sub></a><br /><a href="https://github.com/FritzAndFriends/TagzApp/commits?author=acidrod" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/ryanshaut"><img src="https://github.com/ryanshaut.png?size=100" width="100px;" alt="Ryan Shaut"/><br /><sub><b>Ryan Shaut</b></sub></a><br /><a href="https://github.com/FritzAndFriends/TagzApp/commits?author=ryanshaut" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/ThindalTV"><img src="https://github.com/ThindalTV.png?size=100" width="100px;" alt="Thindal"/><br /><sub><b>Thindal</b></sub></a><br /><a href="https://github.com/FritzAndFriends/TagzApp/commits?author=ThindalTV" title="Code">💻</a></td>
+    </tr>
+  </tbody>
+</table>
+
+<!-- markdownlint-restore -->
+<!-- prettier-ignore-end -->
+
+<!-- ALL-CONTRIBUTORS-LIST:END -->


### PR DESCRIPTION
## Summary
- add the all-contributors badge markers to the top of the README
- add the contributors list section and markers to the README
- add `.all-contributorsrc` so the All Contributors app can manage the panel going forward

## Note
The repository content is configured for the All Contributors app. The remaining step is installing the GitHub App on this repository from GitHub's app installation flow.

Closes #477